### PR TITLE
Handle libzypp lock

### DIFF
--- a/src/lib/configuration_management/runners/base.rb
+++ b/src/lib/configuration_management/runners/base.rb
@@ -114,19 +114,48 @@ module Yast
           false
         end
 
-        # zypp lock file
-        ZYPP_PID = Pathname("/mnt/var/run/zypp.pid")
-        # zypp lock backup file
-        ZYPP_PID_BACKUP = ZYPP_PID.sub_ext(".save")
+        # We're not supposed to call without_zypp_lock recursively.
+        # In that case, we raise an exception to be safe.
+        class WithoutZyppLockNotAllowed < StandardError; end
 
         # Run a block without the zypp lock
         #
+        # You could consider this a hack and it should be used carefully.
+        #
+        # In this case, this behaviour is needed in order to be able to install
+        # packages using a provisioner (Salt, Puppet, etc.). The reason is that
+        # libzypp is locked and it won't be released until YaST finishes (too late).
+        #
         # @param [Proc] Block to run
+        # @see WithouthZyppLockNotAllowed
         def without_zypp_lock(&block)
-          ::FileUtils.mv(ZYPP_PID, ZYPP_PID_BACKUP) if ZYPP_PID.exist?
-          block.call
-        ensure
-          ::FileUtils.mv(ZYPP_PID_BACKUP, ZYPP_PID) if ZYPP_PID_BACKUP.exist?
+          raise WithoutZyppLockNotAllowed if File.exist?(zypp_pid_backup)
+          begin
+            if File.exist?(zypp_pid)
+              log.info "Backing up #{zypp_pid} into #{zypp_pid_backup}"
+              ::FileUtils.mv(zypp_pid, zypp_pid_backup) if File.exist?(zypp_pid)
+            end
+            block.call
+          ensure
+            if File.exist?(zypp_pid_backup)
+              log.info "Restoring #{zypp_pid} from #{zypp_pid_backup}"
+              ::FileUtils.mv(zypp_pid_backup, zypp_pid)
+            end
+          end
+        end
+
+        # Return the libzypp lock file
+        #
+        # @return [Pathname] Absolute path to zypp.pid
+        def zypp_pid
+          @zypp_pid ||= Pathname.new(Installation.destdir).join("var", "run", "zypp.pid")
+        end
+
+        # Return the libzypp backup lock file
+        #
+        # @return [Pathname] Absolute path to zypp.pid backup file
+        def zypp_pid_backup
+          @zypp_pid_backup ||= zypp_pid.sub_ext(".save")
         end
       end
     end

--- a/test/lib/runners/base_spec.rb
+++ b/test/lib/runners/base_spec.rb
@@ -28,11 +28,21 @@ describe Yast::ConfigurationManagement::Runners::Base do
   end
 
   describe "#run" do
-    let(:zypp_pid) { described_class.const_get("ZYPP_PID") }
-    let(:zypp_pid_backup) { described_class.const_get("ZYPP_PID_BACKUP") }
+    let(:zypp_pid) { Pathname.new("/mnt/var/run/zypp.pid") }
+    let(:zypp_pid_backup) { Pathname.new("/mnt/var/run/zypp.save") }
+
+    before do
+      allow(Yast::Installation).to receive(:destdir).and_return("/mnt")
+      allow(File).to receive(:exist?).and_call_original
+    end
 
     context "when a known mode is specified" do
       let(:mode) { :masterless }
+
+      it "tries to run the mode" do
+        expect(runner).to receive(:run_masterless_mode)
+        runner.run
+      end
 
       it "raises a NotImplementedError error" do
         expect { runner.run }.to raise_error(NotImplementedError)
@@ -42,21 +52,57 @@ describe Yast::ConfigurationManagement::Runners::Base do
     context "when a unknown mode is specified" do
       let(:mode) { :unknown }
 
-      it "raises a" do
+      it "raises a NotMethodError" do
         expect { runner.run }.to raise_error(NoMethodError)
       end
     end
 
     context "when zypp is locked" do
       before do
-        allow(zypp_pid).to receive(:exist?).and_return(true)
-        allow(zypp_pid_backup).to receive(:exist?).and_return(true)
+        allow(File).to receive(:exist?).with(zypp_pid).and_return(true)
+        allow(File).to receive(:exist?).with(zypp_pid_backup).and_return(false, true)
         allow(runner).to receive(:run_masterless_mode)
       end
 
-      it "moves and restores the zypp lock" do
-        expect(::FileUtils).to receive(:mv).with(zypp_pid, zypp_pid_backup)
-        expect(::FileUtils).to receive(:mv).with(zypp_pid_backup, zypp_pid)
+      it "backups/restores the zypp lock" do
+        expect(FileUtils).to receive(:mv).with(zypp_pid, zypp_pid_backup)
+        expect(FileUtils).to receive(:mv).with(zypp_pid_backup, zypp_pid)
+        runner.run
+      end
+
+      it "tries to run the mode" do
+        allow(FileUtils).to receive(:mv)
+        expect(runner).to receive(:run_masterless_mode)
+        runner.run
+      end
+    end
+
+    context "when zypp is already temporarily unlocked" do
+      before do
+        allow(File).to receive(:exist?).with(zypp_pid_backup).and_return(true)
+      end
+
+      it "raises an exception" do
+        expect { runner.run }
+          .to raise_error(Yast::ConfigurationManagement::Runners::Base::WithoutZyppLockNotAllowed)
+      end
+    end
+
+    context "when zypp is not locked" do
+      before do
+        allow(File).to receive(:exist?).with(zypp_pid).and_return(false)
+        allow(File).to receive(:exist?).with(zypp_pid_backup).and_return(false)
+        allow(runner).to receive(:run_masterless_mode)
+      end
+
+      it "does not try to backup/restore the zypp lock" do
+        expect(FileUtils).to_not receive(:mv)
+        runner.run
+      end
+
+      it "tries to run the mode" do
+        allow(FileUtils).to receive(:mv)
+        expect(runner).to receive(:run_masterless_mode)
         runner.run
       end
     end


### PR DESCRIPTION
During installation, we have two libzypp lockfiles: one in `/var/run/zypp.pid` and another on in `/mnt/var/run/zypp.pid`. So when the provisioner runs (Salt or Puppet), zypper is locked and you won't be able to install any package.

This code will be executed as part of the [inst_finish](https://github.com/yast/yast-installation/blob/master/src/lib/installation/clients/inst_finish.rb#L395) client as the last save settings step, so I would assume that is safe to backup and restore the libzypp lock.