### PR TITLE
[WIP] Salt Form schema

### DIFF
--- a/jsonschemer
+++ b/jsonschemer
@@ -18,6 +18,10 @@ def load(filename)
   end
 end
 
+def symbolize_hash(h)
+  h.map { |k, v| [k.to_sym, v] }.to_h
+end
+
 schema = load(ARGV[0] || usage!)
 schemer = JSONSchemer.schema(schema)
 
@@ -27,12 +31,13 @@ ARGV[1..-1].each do |fname|
   errors.each do |e|
     fmt = <<~EOS
       Validation error:
+        file:             %{file}
         type:             %{type}
         data:             %{data}
           data pointer:   %{data_pointer}
         schema:           %{schema}
           schema pointer: %{schema_pointer}
       EOS
-    print format(fmt, e.map { |k, v| [k.to_sym, v] }.to_h)
+    print format(fmt, symbolize_hash(e.merge("file" => fname)))
   end
 end

--- a/jsonschemer
+++ b/jsonschemer
@@ -1,7 +1,6 @@
 #!/usr/bin/ruby
 require "json_schemer"
 require "json"
-require "yaml"
 
 def usage!
   puts "Usage: jsonschemer SCHEMA FILE..."
@@ -11,6 +10,7 @@ end
 def load(filename)
   File.open(filename) do |f|
     if filename =~ /\.ya?ml$/
+      require "yaml"
       YAML.load(f, filename)
     else
       JSON.load(f)

--- a/jsonschemer
+++ b/jsonschemer
@@ -1,0 +1,38 @@
+#!/usr/bin/ruby
+require "json_schemer"
+require "json"
+require "yaml"
+
+def usage!
+  puts "Usage: jsonschemer SCHEMA FILE..."
+  exit 1
+end
+
+def load(filename)
+  File.open(filename) do |f|
+    if filename =~ /\.ya?ml$/
+      YAML.load(f, filename)
+    else
+      JSON.load(f)
+    end
+  end
+end
+
+schema = load(ARGV[0] || usage!)
+schemer = JSONSchemer.schema(schema)
+
+ARGV[1..-1].each do |fname|
+  data_o = load(fname)
+  errors = schemer.validate(data_o)
+  errors.each do |e|
+    fmt = <<~EOS
+      Validation error:
+        type:             %{type}
+        data:             %{data}
+          data pointer:   %{data_pointer}
+        schema:           %{schema}
+          schema pointer: %{schema_pointer}
+      EOS
+    print format(fmt, e.map { |k, v| [k.to_sym, v] }.to_h)
+  end
+end

--- a/salt-form.schema.yaml
+++ b/salt-form.schema.yaml
@@ -1,0 +1,107 @@
+---
+# JSON Schema[1] for Salt Forms[2]
+# 1: http://json-schema.org/
+# 2: https://www.suse.com/documentation/suse-manager-3/3.2/susemanager-best-practices/html/book.suma.best.practices/best.practice.salt.formulas.and.forms.html#best.practice.salt.formulas.pillar
+#
+# (The schema is named JSON but it really only cares about structure,
+# so we write both this schema and the validated instances (form.yml) in YAML)
+#
+# The purpose of this schema is to formalize the specification and discover
+# any inconsistencies between the existing documentation and implementations
+#
+# Note about dollars($):
+# JSON schema uses these keywords starting with $:
+# $schema, $id, $ref, $comment.
+# The others (such as $type) are part of the Salt Form vocabulary
+#
+"$schema": "http://json-schema.org/draft-07/schema#"
+"$id": http://yast.opensuse.org/salt-form-01.schema.json
+title: SaltStack Form
+description: Form UI for SaltStack Formulas
+type: object
+
+patternProperties:
+  # any properties not starting with a dollar"
+  "^[^$].*":
+    "$ref": "#" # "recurse, use the top element"
+
+# No other properties allowed other than listed here.
+additionalProperties: false
+
+properties:
+  "$type":
+    description: The type of the pillar value and of the form field
+    enum:
+    # Wiki says these 13
+    - text
+    - password
+    - number
+    - url
+    - email
+    - date
+    - time
+    - datetime
+    - boolean
+    - color
+    - select
+    - group
+    - hidden-group
+    # Best Practices adds these
+    - "namespace" # an alias for "hidden-group"
+    - edit-group
+  "$name":
+    description: the name of a value that is shown in the form.
+    type: string
+  "$help":
+    # FIXME: 'hovering' is too web-specific
+    description: defines the message a user sees when hovering over a field
+    type: string
+  "$placeholder":
+    # $placeholder may only be used with text fields
+    # like text, password, email or date.
+    # It does not make sense to add a placeholder if you also use
+    # $default as this will hide the placeholder.
+    description: displays a gray placeholder text in the field
+    type: string
+  "$default":
+    # FIXME: any value for the above mentioned data types
+    # type: string
+    description: a default value that is displayed and used, if no other value
+      is entered
+  # FIXME: not specified in Wiki or BP!
+  "$optional":
+    type: boolean
+  "$minItems":
+    description: In an edit-group, $minItems and $maxItems allow you
+      to specify the lowest and highest number the group can occur.
+    type: integer
+  "$maxItems":
+    description: In an edit-group, $minItems and $maxItems allow you
+      to specify the lowest and highest number the group can occur.
+    type: integer
+  "$itemName":
+    description: In an edit-group, $itemName allows to define a template
+      for the name to be used for the members of the group.
+    # FIXME: template format? example?
+    type: string
+  "$prototype":
+    description: In an edit-group, $prototype allows to define default
+      (or pre-filled) values for newly added members in the group.
+    "$ref": "#"
+  "$values":
+    description: 'can only be used together with $type: select
+      to specify the different options in the select-field'
+    type: array
+  "$scope":
+    description: allows you to specify a hierarchy level
+      at which a value may be edited
+    # IIUC, "system" is "1 computer", "group" is "many computers"
+    enum:
+    - system
+    - group
+    - readonly
+  "$visibleIf":
+    description: allows you to show a field or group if a simple
+      condition is met
+    # FIXME: specify the mini language
+    type: string

--- a/salt-form.schema.yaml
+++ b/salt-form.schema.yaml
@@ -105,3 +105,14 @@ properties:
       condition is met
     # FIXME: specify the mini language
     type: string
+  # FIXME: not specified!
+  "$key":
+    description: This transforms an edit-group from an array collection
+      to a dictionary collection, and the value specifies a scalar widget
+      that is used as the dictionary key.
+    type: object
+  # FIXME: not specified!
+  "$ifEmpty":
+    description: WTF, how is this different from $default?!
+    # FIXME: any value for the above mentioned data types
+    # type: string


### PR DESCRIPTION
The purpose of this schema is to formalize the specification and discover any inconsistencies between the existing documentation and implementations

This PR has 3 parts
1. the schema
2. an example form which I tested the schema on. Additionally I tested on the [tftpd-formula](#FIXME) form
3. a validator script: it uses the only Rubygem listed at <http://json-schema.org/implementations.html#validators>, which unfortunately does not provide a standalone program, so here I wrote one

