### PR TITLE
Salt form data

### DIFF
--- a/src/lib/y2configuration_management/salt/form_builder.rb
+++ b/src/lib/y2configuration_management/salt/form_builder.rb
@@ -38,7 +38,8 @@ module Y2ConfigurationManagement
       # @param form_element [Y2ConfigurationManagement::Salt::FormElement] Form element
       # @return [Array<Y2ConfigurationManagement::Widgets::AbstractWidget>] List of widgets
       def build(form_element)
-        Array(form_element).map { |e| build_element(e) }
+        widgets = Array(form_element).map { |e| build_element(e) }
+        Y2ConfigurationManagement::Widgets::Form.new(widgets)
       end
 
     private

--- a/src/lib/y2configuration_management/salt/form_builder.rb
+++ b/src/lib/y2configuration_management/salt/form_builder.rb
@@ -36,7 +36,7 @@ module Y2ConfigurationManagement
       # Returns the list of widgets to be included in the form
       #
       # @param form_element [Y2ConfigurationManagement::Salt::FormElement] Form element
-      # @return [Array<Y2ConfigurationManagement::Widgets::AbstractWidget>] List of widgets
+      # @return [Y2ConfigurationManagement::Widgets::Form] Form
       def build(form_element)
         widgets = Array(form_element).map { |e| build_element(e) }
         Y2ConfigurationManagement::Widgets::Form.new(widgets)

--- a/src/lib/y2configuration_management/salt/form_controller.rb
+++ b/src/lib/y2configuration_management/salt/form_controller.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "y2configuration_management/salt/form_builder"
+require "y2configuration_management/salt/form_data"
 require "y2configuration_management/widgets/form_popup"
 
 Yast.import "CWM"
@@ -38,17 +39,19 @@ module Y2ConfigurationManagement
       # Constructor
       #
       # @param form [Y2ConfigurationManagement::Salt::Form] Form
-      # @param state [Hash] Current state (TODO)
-      def initialize(form, state = {})
-        textdomain "configuration_management"
 
-        @state = state # TODO
+      def initialize(form)
+        @data = FormData.new(form)
         @form = form
       end
 
       # Renders the main form's dialog
       def show_main_dialog
         show_dialog(form.root.name, form_builder.build(form.root.elements))
+      end
+
+      def get(path)
+        @data.get(path)
       end
 
       # Opens a new dialog in order to add a new element to a collection
@@ -60,7 +63,7 @@ module Y2ConfigurationManagement
 
     private
 
-      attr_reader :form, :state
+      attr_reader :form, :data
 
       # Returns the form builder
       #

--- a/src/lib/y2configuration_management/salt/form_controller.rb
+++ b/src/lib/y2configuration_management/salt/form_controller.rb
@@ -64,7 +64,6 @@ module Y2ConfigurationManagement
       # @param path [String] Collection's path
       def add(path)
         element = form.find_element_by(path: path).prototype
-        widget_form = form_builder.build(element)
         result = show_popup(element.name, form_builder.build(element))
         return if result.nil?
         @data.add(path, result.values.first)
@@ -89,17 +88,6 @@ module Y2ConfigurationManagement
       # @return [Y2ConfigurationManagement::Salt::FormBuilder]
       def form_builder
         @form_builder ||= Y2ConfigurationManagement::Salt::FormBuilder.new(self)
-      end
-
-      # Displays a form dialog
-      #
-      # @param title       [String] Dialog title
-      # @param widget_form [Y2ConfigurationManagement::Widgets:Form] Form to show
-      def show_dialog(widget_form)
-        Yast::CWM.show(
-          HBox(replace_point),
-          caption: form.root.name, next_handler: method(:next_handler)
-        )
       end
 
       # Renders the main form's dialog

--- a/src/lib/y2configuration_management/salt/form_controller.rb
+++ b/src/lib/y2configuration_management/salt/form_controller.rb
@@ -129,6 +129,10 @@ module Y2ConfigurationManagement
       #   version.
       def next_handler
         return false unless Yast::Popup.YesNo("Do you want to exit?")
+        # This does not work. should main_form be memoized?
+        #   main_form.store
+        #   data.update(form.root.path, main_form.result)
+        data.update(form.root.path, main_form.store)
         puts data.to_h.inspect
         true
       end

--- a/src/lib/y2configuration_management/salt/form_controller.rb
+++ b/src/lib/y2configuration_management/salt/form_controller.rb
@@ -39,7 +39,6 @@ module Y2ConfigurationManagement
       # Constructor
       #
       # @param form [Y2ConfigurationManagement::Salt::Form] Form
-
       def initialize(form)
         @data = FormData.new(form)
         @form = form
@@ -112,7 +111,7 @@ module Y2ConfigurationManagement
       # Displays a popup
       #
       # @param title    [String] Popup title
-      # @param contents [Array<CWM::AbstractWidget>] Popup content (as an array of CWM widgets)
+      # @param widget [Array<CWM::AbstractWidget>] Popup content (as an array of CWM widgets)
       # @return [Hash,nil] Dialog's result
       def show_popup(title, widget)
         Widgets::FormPopup.new(title, widget).run

--- a/src/lib/y2configuration_management/salt/form_controller.rb
+++ b/src/lib/y2configuration_management/salt/form_controller.rb
@@ -91,6 +91,17 @@ module Y2ConfigurationManagement
         @form_builder ||= Y2ConfigurationManagement::Salt::FormBuilder.new(self)
       end
 
+      # Displays a form dialog
+      #
+      # @param title       [String] Dialog title
+      # @param widget_form [Y2ConfigurationManagement::Widgets:Form] Form to show
+      def show_dialog(widget_form)
+        Yast::CWM.show(
+          HBox(replace_point),
+          caption: form.root.name, next_handler: method(:next_handler)
+        )
+      end
+
       # Renders the main form's dialog
       def main_form
         widget_form = form_builder.build(form.root.elements)

--- a/src/lib/y2configuration_management/salt/form_controller.rb
+++ b/src/lib/y2configuration_management/salt/form_controller.rb
@@ -51,9 +51,13 @@ module Y2ConfigurationManagement
           HBox(replace_point),
           caption: form.root.name, next_handler: method(:next_handler)
         )
+      ensure
         Yast::Wizard.CloseDialog
       end
 
+      # Convenience method for returning the value of a given element
+      #
+      # @param path [String] Path to the element
       def get(path)
         @data.get(path)
       end
@@ -80,7 +84,10 @@ module Y2ConfigurationManagement
 
     private
 
-      attr_reader :form, :data
+      # @return [Form]
+      attr_reader :form
+      # @return [FormData]
+      attr_reader :data
 
       # Returns the form builder
       #

--- a/src/lib/y2configuration_management/salt/form_data.rb
+++ b/src/lib/y2configuration_management/salt/form_data.rb
@@ -58,7 +58,9 @@ module Y2ConfigurationManagement
       # @param value [Object] New value
       def update(path, value)
         parts = path_to_parts(path)
-        parent = @data.dig(*parts[0..-2])
+        parent_parts = parts[0..-2]
+        parent = @data
+        parent = parent.dig(* parent_parts) unless parent_parts.empty?
         parent[parts.last] = value
       end
 

--- a/src/lib/y2configuration_management/salt/form_data.rb
+++ b/src/lib/y2configuration_management/salt/form_data.rb
@@ -96,15 +96,15 @@ module Y2ConfigurationManagement
 
       # Builds a hash to keep the form data
       #
-      # @param [Y2ConfigurationManagement::Salt::Form]
+      # @param form [Y2ConfigurationManagement::Salt::Form]
       # @return [Hash]
       def data_for_form(form)
         data_for_element(form.root)
       end
 
-      # Builds a hash to keep the form data
+      # Builds a hash to keep the form element data
       #
-      # @param [Y2ConfigurationManagement::Salt::Form]
+      # @param element [Y2ConfigurationManagement::Salt::FormElement]
       # @return [Hash]
       def data_for_element(element)
         if element.is_a?(Container)

--- a/src/lib/y2configuration_management/salt/form_data.rb
+++ b/src/lib/y2configuration_management/salt/form_data.rb
@@ -1,0 +1,119 @@
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Y2ConfigurationManagement
+  module Salt
+    # This class holds data for a given Salt Formula Form
+    #
+    # @todo The support for collections is rather simple and nesting collections is not supported.
+    #       We might consider using JSON Patch to modify the data.
+    class FormData
+      # @return [Y2ConfigurationManagement::Salt::Form] Form
+      attr_reader :form
+
+      # Constructor
+      #
+      # @param form [Y2ConfigurationManagement::Salt::Form] Form
+      def initialize(form)
+        @data = data_for_form(form)
+        @form = form
+      end
+
+      # Returns the value of a given element
+      #
+      # @param path [String] Path to the element
+      def get(path)
+        @data.dig(*path_to_parts(path)) || default_for(path)
+      end
+
+      # Adds an element to a collection
+      #
+      # @param path  [String] Path to the collection
+      # @param value [Hash] Value to add
+      def add(path, value)
+        collection = get(path)
+        collection.push(value)
+      end
+
+      # Updates an element's value
+      #
+      # @param path  [String] Path to the collection
+      # @param value [Object] New value
+      def update(path, value)
+        parts = path_to_parts(path)
+        parent = @data.dig(*parts[0..-2])
+        parent[parts.last] = value
+      end
+
+      # Removes an element from a collection
+      #
+      # @param path  [String]  Path to the collection
+      # @param index [Integer] Position of the element to remove
+      def remove(path, index)
+        collection = get(path)
+        collection.delete_at(index)
+      end
+
+      # Returns a hash containing the form data
+      #
+      # @return [Hash]
+      def to_h
+        @data
+      end
+
+    private
+
+      # Default value for a given element
+      #
+      # @param path [String] Element path
+      def default_for(path)
+        element = form.find_element_by(path: path)
+        element ? element.default : nil
+      end
+
+      # Split the path into different parts
+      #
+      # @param path [String] Element path
+      def path_to_parts(path)
+        path[1..-1].split(".")
+      end
+
+      # Builds a hash to keep the form data
+      #
+      # @param [Y2ConfigurationManagement::Salt::Form]
+      # @return [Hash]
+      def data_for_form(form)
+        data_for_element(form.root)
+      end
+
+      # Builds a hash to keep the form data
+      #
+      # @param [Y2ConfigurationManagement::Salt::Form]
+      # @return [Hash]
+      def data_for_element(element)
+        if element.is_a?(Container)
+          defaults = element.elements.reduce({}) { |a, e| a.merge(data_for_element(e)) }
+          { element.id => defaults }
+        else
+          { element.id => element.default }
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2configuration_management/salt/form_data.rb
+++ b/src/lib/y2configuration_management/salt/form_data.rb
@@ -24,6 +24,7 @@ module Y2ConfigurationManagement
     # @todo The support for collections is rather simple and nesting collections is not supported.
     #       We might consider using JSON Patch to modify the data.
     class FormData
+      PATH_DELIMITER = ".".freeze
       # @return [Y2ConfigurationManagement::Salt::Form] Form
       attr_reader :form
 
@@ -91,7 +92,7 @@ module Y2ConfigurationManagement
       #
       # @param path [String] Element path
       def path_to_parts(path)
-        path[1..-1].split(".")
+        path[1..-1].split(PATH_DELIMITER)
       end
 
       # Builds a hash to keep the form data

--- a/src/lib/y2configuration_management/widgets/boolean.rb
+++ b/src/lib/y2configuration_management/widgets/boolean.rb
@@ -30,6 +30,8 @@ module Y2ConfigurationManagement
       attr_reader :default
       # @return [String] Form path
       attr_reader :path
+      # @return [String] Form element id
+      attr_reader :id
 
       # Constructor
       #
@@ -40,6 +42,7 @@ module Y2ConfigurationManagement
         @default = spec.default == true # nil -> false
         @controller = controller
         @path = spec.path
+        @id = spec.id
         self.widget_id = "boolean:#{spec.id}"
       end
 

--- a/src/lib/y2configuration_management/widgets/collection.rb
+++ b/src/lib/y2configuration_management/widgets/collection.rb
@@ -50,10 +50,10 @@ module Y2ConfigurationManagement
       def contents
         VBox(
           Table(
-            Id("table_#{widget_id}"),
+            Id("table:#{path}"),
             Opt(:notify, :immediate),
-            Header(label),
-            []
+            Header(*headers),
+            items_list
           ),
           HBox(
             HStretch(),
@@ -97,8 +97,27 @@ module Y2ConfigurationManagement
       #
       # @return [Integer,nil] Index of the selected row or nil if no row is selected
       def selected_row
-        row_id = UI.QueryWidget(Id("table_#{widget_id}"), :CurrentItem)
+        row_id = Yast::UI.QueryWidget(Id("table:#{path}"), :CurrentItem)
         row_id ? row_id.to_i : nil
+      end
+
+      # Returns the headers for the collection table
+      #
+      # @todo Get this information from the formula spec
+      #
+      # @return [Array<String>]
+      def headers
+        value.first.keys
+      end
+
+      # Format the items list for the colletion table
+      #
+      # @return [Array<Array<String|Yast::Term>>]
+      def items_list
+        value.each_with_index.map do |item, index|
+          values = headers.map { |h| item[h] }
+          Item(Id(index.to_s), *values)
+        end
       end
     end
   end

--- a/src/lib/y2configuration_management/widgets/collection.rb
+++ b/src/lib/y2configuration_management/widgets/collection.rb
@@ -28,6 +28,8 @@ module Y2ConfigurationManagement
     # buttons to add, remove and edit them.
     class Collection < ::CWM::CustomWidget
       attr_reader :label, :min_items, :max_items, :controller, :path, :id
+      # @return [Array<Object>] List of objects which are included in the collection
+      attr_accessor :value
 
       # Constructor
       #
@@ -42,6 +44,7 @@ module Y2ConfigurationManagement
         @path = spec.path # form element path
         @id = spec.id
         self.widget_id = "collection:#{spec.id}"
+        self.value = []
       end
 
       # Widget contents
@@ -86,6 +89,7 @@ module Y2ConfigurationManagement
         when "#{widget_id}_remove".to_sym
           # TODO
           # controller.remove(path, selected_row) if selected_row
+          controller.remove(path, selected_row) if selected_row
         end
 
         nil
@@ -107,6 +111,7 @@ module Y2ConfigurationManagement
       #
       # @return [Array<String>]
       def headers
+        return unless value.first
         value.first.keys
       end
 

--- a/src/lib/y2configuration_management/widgets/collection.rb
+++ b/src/lib/y2configuration_management/widgets/collection.rb
@@ -27,7 +27,7 @@ module Y2ConfigurationManagement
     # This widget uses a table to display a collection of elements and offers
     # buttons to add, remove and edit them.
     class Collection < ::CWM::CustomWidget
-      attr_reader :label, :min_items, :max_items, :controller, :path
+      attr_reader :label, :min_items, :max_items, :controller, :path, :id
 
       # Constructor
       #
@@ -40,6 +40,7 @@ module Y2ConfigurationManagement
         @max_items = spec.max_items
         @controller = controller
         @path = spec.path # form element path
+        @id = spec.id
         self.widget_id = "collection:#{spec.id}"
       end
 

--- a/src/lib/y2configuration_management/widgets/form.rb
+++ b/src/lib/y2configuration_management/widgets/form.rb
@@ -49,9 +49,9 @@ module Y2ConfigurationManagement
       # This method propagates the values to the underlying widgets.
       #
       # @example Setting values for included widgets
-      #   form.values = { "name" => "John", "surname" => "Doe" }
+      #   form.value = { "name" => "John", "surname" => "Doe" }
       # @example Setting values for nested widgets
-      #   form.values = { "ranges" => [ { "start" => "10.0.0.10", "end" => "10.0.0.20" } ] }
+      #   form.value = { "ranges" => [ { "start" => "10.0.0.10", "end" => "10.0.0.20" } ] }
       #
       # @param value [Hash] New value
       def value=(value)

--- a/src/lib/y2configuration_management/widgets/form.rb
+++ b/src/lib/y2configuration_management/widgets/form.rb
@@ -53,7 +53,7 @@ module Y2ConfigurationManagement
       # @example Setting values for nested widgets
       #   form.values = { "ranges" => [ { "start" => "10.0.0.10", "end" => "10.0.0.20" } ] }
       #
-      # @return value [Hash] New value
+      # @param value [Hash] New value
       def value=(value)
         children.each do |widget|
           widget.value = value[widget.id]

--- a/src/lib/y2configuration_management/widgets/form.rb
+++ b/src/lib/y2configuration_management/widgets/form.rb
@@ -73,7 +73,7 @@ module Y2ConfigurationManagement
       #
       # @see CWM::AbstractWidget
       def store
-        @result = children.reduce({}) { |h, w| h.merge(w.id => w.value) }
+        @result = children.reduce({}) { |a, e| a.merge(e.id => e.value) }
       end
     end
   end

--- a/src/lib/y2configuration_management/widgets/form.rb
+++ b/src/lib/y2configuration_management/widgets/form.rb
@@ -1,0 +1,80 @@
+# encoding: utf-8
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "cwm"
+
+module Y2ConfigurationManagement
+  module Widgets
+    # Widget which represents a Salt Formula Form
+    #
+    # This acts as a container for those all the widgets that are related to a formula
+    # and takes care of:
+    #
+    # * Initializing the included widgets (see #value)...
+    # * and storing the final result (see #store and #result).
+    # It is able
+    class Form < ::CWM::CustomWidget
+      # @return [Array<CWM::AbstractWidget>] Widgets included in the form
+      attr_reader :children
+      # @return [Hash] Form values from included widgets when this one is removed from the UI
+      attr_reader :result
+
+      # Constructor
+      #
+      # @param children [Array<CWM::AbstractWidget>] Widgets included in the form
+      def initialize(children)
+        @children = children
+      end
+
+      # Sets the value for the form
+      #
+      # This method propagates the values to the underlying widgets.
+      #
+      # @example Setting values for included widgets
+      #   form.values = { "name" => "John", "surname" => "Doe" }
+      # @example Setting values for nested widgets
+      #   form.values = { "ranges" => [ { "start" => "10.0.0.10", "end" => "10.0.0.20" } ] }
+      #
+      # @return value [Hash] New value
+      def value=(value)
+        children.each do |widget|
+          widget.value = value[widget.id]
+        end
+      end
+
+      # Widget's content
+      #
+      # @see CWM::AbstractWidget
+      def contents
+        VBox(*children)
+      end
+
+      # Stores the widget's content
+      #
+      # The stored value can be obtained using the #result method
+      #
+      # @see CWM::AbstractWidget
+      def store
+        @result = children.reduce({}) { |h, w| h.merge(w.id => w.value) }
+      end
+    end
+  end
+end

--- a/src/lib/y2configuration_management/widgets/group.rb
+++ b/src/lib/y2configuration_management/widgets/group.rb
@@ -77,7 +77,7 @@ module Y2ConfigurationManagement
       # @return value [Hash] New value
       # @see #value=
       def value
-        children.reduce({}) { |h, w| h.merge(w.id => w.value) }
+        children.reduce({}) { |a, e| a.merge(e.id => e.value) }
       end
     end
   end

--- a/src/lib/y2configuration_management/widgets/group.rb
+++ b/src/lib/y2configuration_management/widgets/group.rb
@@ -29,7 +29,6 @@ module Y2ConfigurationManagement
       attr_reader :path
       # @return [Array<CWM::AbstractWidget>] Widgets which are included in the group
       attr_reader :children
-      # @return [String] Form element id
       attr_reader :id
 
       # Constructor
@@ -52,6 +51,33 @@ module Y2ConfigurationManagement
       # @return [Yast::Term]
       def contents
         VBox(*children)
+      end
+
+      # Sets the value for the form
+      #
+      # This method propagates the values to the underlying widgets.
+      #
+      # @example Setting values for included widgets
+      #   form.values = { "name" => "John", "surname" => "Doe" }
+      # @example Setting values for nested widgets
+      #   form.values = { "ranges" => [ { "start" => "10.0.0.10", "end" => "10.0.0.20" } ] }
+      #
+      # @return value [Hash] New value
+      def value=(values)
+        children.each do |widget|
+          widget.value = values[widget.id]
+        end
+      end
+
+      # Returns form widgets
+      #
+      # This method gets the values from the underlying widgets returning them in a
+      # hash index by widget ids.
+      #
+      # @return value [Hash] New value
+      # @see #value=
+      def value
+        children.reduce({}) { |h, w| h.merge(w.id => w.value) }
       end
     end
   end

--- a/src/lib/y2configuration_management/widgets/group.rb
+++ b/src/lib/y2configuration_management/widgets/group.rb
@@ -58,9 +58,9 @@ module Y2ConfigurationManagement
       # This method propagates the values to the underlying widgets.
       #
       # @example Setting values for included widgets
-      #   form.values = { "name" => "John", "surname" => "Doe" }
+      #   form.value = { "name" => "John", "surname" => "Doe" }
       # @example Setting values for nested widgets
-      #   form.values = { "ranges" => [ { "start" => "10.0.0.10", "end" => "10.0.0.20" } ] }
+      #   form.value = { "ranges" => [ { "start" => "10.0.0.10", "end" => "10.0.0.20" } ] }
       #
       # @param values [Hash] New value
       def value=(values)

--- a/src/lib/y2configuration_management/widgets/group.rb
+++ b/src/lib/y2configuration_management/widgets/group.rb
@@ -62,7 +62,7 @@ module Y2ConfigurationManagement
       # @example Setting values for nested widgets
       #   form.values = { "ranges" => [ { "start" => "10.0.0.10", "end" => "10.0.0.20" } ] }
       #
-      # @return value [Hash] New value
+      # @param values [Hash] New value
       def value=(values)
         children.each do |widget|
           widget.value = values[widget.id]
@@ -74,7 +74,7 @@ module Y2ConfigurationManagement
       # This method gets the values from the underlying widgets returning them in a
       # hash index by widget ids.
       #
-      # @return value [Hash] New value
+      # @return [Hash]
       # @see #value=
       def value
         children.reduce({}) { |a, e| a.merge(e.id => e.value) }

--- a/src/lib/y2configuration_management/widgets/group.rb
+++ b/src/lib/y2configuration_management/widgets/group.rb
@@ -29,6 +29,8 @@ module Y2ConfigurationManagement
       attr_reader :path
       # @return [Array<CWM::AbstractWidget>] Widgets which are included in the group
       attr_reader :children
+      # @return [String] Form element id
+      attr_reader :id
 
       # Constructor
       #
@@ -41,6 +43,7 @@ module Y2ConfigurationManagement
         @children = children
         @controller = controller
         @path = spec.path
+        @id = spec.id
         self.widget_id = "group:#{spec.id}"
       end
 

--- a/src/lib/y2configuration_management/widgets/select.rb
+++ b/src/lib/y2configuration_management/widgets/select.rb
@@ -31,6 +31,8 @@ module Y2ConfigurationManagement
       attr_reader :default
       # @return [String] Form element path
       attr_reader :path
+      # @return [String] Form element id
+      attr_reader :id
 
       # Constructor
       #
@@ -41,6 +43,7 @@ module Y2ConfigurationManagement
         @items = spec.values.each_with_index.map { |v, i| [i.to_s, v] }
         @default = spec.default
         @path = spec.path
+        @id = spec.id
         @controller = controller
         self.widget_id = "select:#{spec.id}"
       end

--- a/src/lib/y2configuration_management/widgets/select.rb
+++ b/src/lib/y2configuration_management/widgets/select.rb
@@ -40,7 +40,7 @@ module Y2ConfigurationManagement
       # @param controller [Y2ConfigurationManagement::Salt::FormController] Form controller
       def initialize(spec, controller)
         @label = spec.label
-        @items = spec.values.each_with_index.map { |v, i| [i.to_s, v] }
+        @items = spec.values.map { |v| [v, v] }
         @default = spec.default
         @path = spec.path
         @id = spec.id

--- a/src/lib/y2configuration_management/widgets/text.rb
+++ b/src/lib/y2configuration_management/widgets/text.rb
@@ -30,6 +30,8 @@ module Y2ConfigurationManagement
       attr_reader :default
       # @return [String] Form path
       attr_reader :path
+      # @return [String] Form element id
+      attr_reader :id
 
       # Constructor
       #
@@ -40,6 +42,7 @@ module Y2ConfigurationManagement
         @default = spec.default.to_s
         @controller = controller
         @path = spec.path
+        @id = spec.id
         self.widget_id = "text:#{spec.id}"
       end
 

--- a/test/fixtures/form.yml
+++ b/test/fixtures/form.yml
@@ -7,6 +7,7 @@ person:
   email:
     "$name": "E-mail"
     "$type": email
+    "$default": "somebody@example.net"
   wants_newsletter:
     "$type": boolean
     "$default": true
@@ -25,6 +26,9 @@ person:
     "$type": edit-group
     "$minItems": 1
     "$maxItems": 4
+    "$default":
+      - brand: ACME
+        disks: 1
     "$prototype":
       $type: group
       brand:

--- a/test/y2configuration_management/salt/form_builder_test.rb
+++ b/test/y2configuration_management/salt/form_builder_test.rb
@@ -34,10 +34,10 @@ describe Y2ConfigurationManagement::Salt::FormBuilder do
     context "when an input form element is given" do
       let(:path) { ".root.person.name" }
 
-      it "returns an array containing a text widget" do
-        widgets = builder.build(element)
-        expect(widgets).to be_all(Y2ConfigurationManagement::Widgets::Text)
-        expect(widgets).to contain_exactly(
+      it "returns a form containing a text widget" do
+        form = builder.build(element)
+        expect(form.children).to be_all(Y2ConfigurationManagement::Widgets::Text)
+        expect(form.children).to contain_exactly(
           an_object_having_attributes(
             "path" => ".root.person.name"
           )
@@ -48,9 +48,9 @@ describe Y2ConfigurationManagement::Salt::FormBuilder do
     context "when a group form element is given" do
       let(:path) { ".root.person.address" }
 
-      it "returns an array containing a group widgets" do
-        widgets = builder.build(element)
-        group = widgets.first
+      it "returns a form containing a group widgets" do
+        form = builder.build(element)
+        group = form.children.first
         expect(group.children).to contain_exactly(
           an_object_having_attributes("path" => ".root.person.address.street"),
           an_object_having_attributes("path" => ".root.person.address.country")
@@ -61,9 +61,9 @@ describe Y2ConfigurationManagement::Salt::FormBuilder do
     context "when a collection is given" do
       let(:path) { ".root.person.computers" }
 
-      it "returns an array containing a collection widget" do
-        widgets = builder.build(element)
-        expect(widgets).to be_all(Y2ConfigurationManagement::Widgets::Collection)
+      it "returns a form containing a collection widget" do
+        form = builder.build(element)
+        expect(form.children).to be_all(Y2ConfigurationManagement::Widgets::Collection)
       end
     end
   end

--- a/test/y2configuration_management/salt/form_controller_test.rb
+++ b/test/y2configuration_management/salt/form_controller_test.rb
@@ -30,8 +30,11 @@ describe Y2ConfigurationManagement::Salt::FormController do
   end
 
   let(:builder) { Y2ConfigurationManagement::Salt::FormBuilder.new(controller) }
+  let(:data) { Y2ConfigurationManagement::Salt::FormData.new(form) }
 
   before do
+    allow(Y2ConfigurationManagement::Salt::FormData).to receive(:new)
+      .and_return(data)
     allow(Y2ConfigurationManagement::Salt::FormBuilder).to receive(:new)
       .with(controller).and_return(builder)
   end
@@ -46,5 +49,12 @@ describe Y2ConfigurationManagement::Salt::FormController do
 
   describe "#add" do
     it "opens the dialog using the collections's prototype"
+  end
+
+  describe "#remove" do
+    it "removes an element" do
+      expect(data).to receive(:remove).with(".root.person.computers", 1)
+      controller.remove(".root.person.computers", 1)
+    end
   end
 end

--- a/test/y2configuration_management/salt/form_controller_test.rb
+++ b/test/y2configuration_management/salt/form_controller_test.rb
@@ -48,7 +48,41 @@ describe Y2ConfigurationManagement::Salt::FormController do
   end
 
   describe "#add" do
-    it "opens the dialog using the collections's prototype"
+    let(:path) { ".root.person.computers" }
+    let(:popup) { instance_double(Y2ConfigurationManagement::Widgets::FormPopup, run: nil) }
+    let(:widget) { instance_double(Y2ConfigurationManagement::Widgets::Form, result: result) }
+    let(:result) { nil }
+    let(:prototype) { form.find_element_by(path: path).prototype }
+
+    before do
+      allow(Y2ConfigurationManagement::Widgets::FormPopup)
+        .to receive(:new).and_return(popup)
+      allow(builder).to receive(:build).and_call_original
+      allow(builder).to receive(:build).with(prototype).and_return(widget)
+    end
+
+    it "opens the dialog using the collections's prototype" do
+      expect(builder).to receive(:build).with(prototype).and_return(widget)
+      controller.add(path)
+    end
+
+    context "when the user accepts the dialog" do
+      let(:result) { { "computers" =>  { "brand" => "Lenovo", "disks" => 2 } } }
+
+      it "updates the form data" do
+        controller.add(path)
+        expect(data.get(".root.person.computers")).to include("brand" => "Lenovo", "disks" => 2)
+      end
+    end
+
+    context "when the user cancels the dialog" do
+      let(:result) { nil }
+
+      it "does not modify form data" do
+        expect(data).to_not receive(:add)
+        controller.add(path)
+      end
+    end
   end
 
   describe "#remove" do

--- a/test/y2configuration_management/salt/form_data_test.rb
+++ b/test/y2configuration_management/salt/form_data_test.rb
@@ -1,0 +1,74 @@
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../spec_helper"
+require "y2configuration_management/salt/form"
+require "y2configuration_management/salt/form_data"
+
+describe Y2ConfigurationManagement::Salt::FormData do
+  subject(:form_data) { described_class.new(form) }
+
+  let(:form) do
+    Y2ConfigurationManagement::Salt::Form.from_file(FIXTURES_PATH.join("form.yml"))
+  end
+
+  describe "#get" do
+    context "when the value has not been set" do
+      it "returns the default value" do
+        expect(form_data.get(".root.person.name")).to eq("John Doe")
+      end
+
+      context "and it is a collection" do
+        it "returns a hash with the default values" do
+          expect(form_data.get(".root.person.computers"))
+            .to eq([{ "brand" => "ACME", "disks" => 1 }])
+        end
+      end
+    end
+
+    context "when the value has been set" do
+      before do
+        form_data.update(".root.person.name", "Mr. Doe")
+      end
+
+      it "returns the already set value" do
+        expect(form_data.get(".root.person.name")).to eq("Mr. Doe")
+      end
+    end
+  end
+
+  describe "#add" do
+    it "adds the element to the collection" do
+      form_data.add(".root.person.computers", "brand" => "Dell", "disks" => 2)
+      expect(form_data.get(".root.person.computers")).to eq(
+        [
+          { "brand" => "ACME", "disks" => 1 },
+          { "brand" => "Dell", "disks" => 2 }
+        ]
+      )
+    end
+  end
+
+  describe "#remove" do
+    it "removes the element from the collection" do
+      form_data.remove(".root.person.computers", 0)
+      expect(form_data.get(".root.person.computers")).to be_empty
+    end
+  end
+end

--- a/test/y2configuration_management/widgets/collection_test.rb
+++ b/test/y2configuration_management/widgets/collection_test.rb
@@ -1,3 +1,4 @@
+#!/usr/bin/env rspec
 # Copyright (c) [2018] SUSE LLC
 #
 # All Rights Reserved.
@@ -46,7 +47,7 @@ describe Y2ConfigurationManagement::Widgets::Collection do
 
   describe "#handle" do
     context "when it is an 'add' event" do
-      let(:event) { { "ID" => :add } }
+      let(:event) { { "ID" => "#{collection.widget_id}_add".to_sym } }
 
       it "adds a new element to the collection" do
         expect(controller).to receive(:add).with(path)
@@ -55,7 +56,7 @@ describe Y2ConfigurationManagement::Widgets::Collection do
     end
 
     context "when it is an 'remove' event" do
-      let(:event) { { "ID" => :remove } }
+      let(:event) { { "ID" => "#{collection.widget_id}_remove".to_sym } }
 
       before do
         allow(collection).to receive(:selected_row).and_return(1)

--- a/test/y2configuration_management/widgets/collection_test.rb
+++ b/test/y2configuration_management/widgets/collection_test.rb
@@ -43,4 +43,28 @@ describe Y2ConfigurationManagement::Widgets::Collection do
       expect(collection.max_items).to eq(4)
     end
   end
+
+  describe "#handle" do
+    context "when it is an 'add' event" do
+      let(:event) { { "ID" => :add } }
+
+      it "adds a new element to the collection" do
+        expect(controller).to receive(:add).with(path)
+        collection.handle(event)
+      end
+    end
+
+    context "when it is an 'remove' event" do
+      let(:event) { { "ID" => :remove } }
+
+      before do
+        allow(collection).to receive(:selected_row).and_return(1)
+      end
+
+      it "removes the selected element from the collection" do
+        expect(controller).to receive(:remove).with(path, 1)
+        collection.handle(event)
+      end
+    end
+  end
 end

--- a/test/y2configuration_management/widgets/form_test.rb
+++ b/test/y2configuration_management/widgets/form_test.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
 # Copyright (c) [2018] SUSE LLC
 #
 # All Rights Reserved.
@@ -17,9 +20,27 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2configuration_management/widgets/boolean"
-require "y2configuration_management/widgets/collection"
-require "y2configuration_management/widgets/group"
-require "y2configuration_management/widgets/select"
-require "y2configuration_management/widgets/text"
+require_relative "../../spec_helper"
 require "y2configuration_management/widgets/form"
+require "y2configuration_management/widgets/text"
+
+describe Y2ConfigurationManagement::Widgets::Form do
+  subject(:form) { described_class.new([text_input]) }
+  let(:text_input) do
+    instance_double(Y2ConfigurationManagement::Widgets::Text, id: "text1", value: "foobar")
+  end
+
+  describe "#value" do
+    it "sets values for underlying widgets" do
+      expect(text_input).to receive(:value=).with("example")
+      form.value = { "text1" => "example" }
+    end
+  end
+
+  describe "#store" do
+    it "stores the final result" do
+      form.store
+      expect(form.result).to eq("text1" => "foobar")
+    end
+  end
+end

--- a/test/y2configuration_management/widgets/group_test.rb
+++ b/test/y2configuration_management/widgets/group_test.rb
@@ -35,12 +35,19 @@ describe Y2ConfigurationManagement::Widgets::Group do
   let(:spec) { form_spec.find_element_by(path: path) }
   let(:path) { ".root.person.address" }
   let(:controller) { instance_double(Y2ConfigurationManagement::Salt::FormController) }
-  let(:widget1) { instance_double(Y2ConfigurationManagement::Widgets::Text) }
+  let(:widget1) { instance_double(Y2ConfigurationManagement::Widgets::Text, id: "widget1") }
 
   describe ".new" do
     it "instantiates a new widget according to the spec" do
       group = described_class.new(spec, [widget1], controller)
       expect(group.path).to eq(path)
+    end
+  end
+
+  describe "#value=" do
+    it "sets values of underlying widgets" do
+      expect(widget).to receive(:value=).with("foobar")
+      widget.value = { "widget1" => "foobar" }
     end
   end
 end

--- a/test/y2configuration_management/widgets/group_test.rb
+++ b/test/y2configuration_management/widgets/group_test.rb
@@ -46,8 +46,8 @@ describe Y2ConfigurationManagement::Widgets::Group do
 
   describe "#value=" do
     it "sets values of underlying widgets" do
-      expect(widget).to receive(:value=).with("foobar")
-      widget.value = { "widget1" => "foobar" }
+      expect(widget1).to receive(:value=).with("foobar")
+      group.value = { "widget1" => "foobar" }
     end
   end
 end

--- a/test/y2configuration_management/widgets/select_test.rb
+++ b/test/y2configuration_management/widgets/select_test.rb
@@ -39,14 +39,15 @@ describe Y2ConfigurationManagement::Widgets::Select do
     it "instantiates a new widget according to the spec" do
       selector = described_class.new(spec, controller)
       expect(selector.path).to eq(path)
-      expect(selector.items).to eq([["0", "Czech Republic"], ["1", "Germany"], ["2", "Spain"]])
+      expect(selector.items)
+        .to eq([["Czech Republic", "Czech Republic"], ["Germany", "Germany"], ["Spain", "Spain"]])
       expect(selector.default).to eq("Czech Republic")
     end
   end
 
   describe "#init" do
     it "initializes the current value to the default one" do
-      expect(selector).to receive(:value=).with("0")
+      expect(selector).to receive(:value=).with("Czech Republic")
       selector.init
     end
 


### PR DESCRIPTION
This PR adds support to store the data from the form so it can be exported later to be used as part of a Pillar.

Basically, a new `FormData` class has been added which offers an API to add, update and remove information (including collections). The data is referred using a regular path (eg. `.root.person`) and it is stored in a hash.

To avoid coupling the widgets with the form data, a new `Form` widget has been introduced. To populate the form with the initial values, the `#value=` method is used (values are then propagated to internal widgets). The `#result` method offers a way to get the final values.

## In scope

* Store the data from the forms.
* Add and remove elements to/from a collection.

## Out of scope

* Editing existing elemens within a collection.
* Exporting the data to a Pillar, although the `test_formula` client dumps the result to the standard output.