### PR TITLE
Collection fixes

### DIFF
--- a/src/lib/y2configuration_management/salt/form.rb
+++ b/src/lib/y2configuration_management/salt/form.rb
@@ -243,7 +243,7 @@ module Y2ConfigurationManagement
         @min_items = spec["$minItems"] if spec["$minItems"]
         @max_items = spec["$maxItems"] if spec["$maxItems"]
         @prototype = prototype_for(id, spec)
-        @default = spec["$default"] if spec["$default"]
+        @default = spec.fetch("$default", [])
       end
 
     private

--- a/src/lib/y2configuration_management/widgets/collection.rb
+++ b/src/lib/y2configuration_management/widgets/collection.rb
@@ -123,7 +123,11 @@ module Y2ConfigurationManagement
       # @return [Array<Array<String|Yast::Term>>]
       def format_items(items_list)
         items_list.each_with_index.map do |item, index|
-          values = headers_ids.map { |h| item[h] }
+          values = if item.is_a? Hash
+            headers_ids.map { |h| item[h] }
+          else
+            [item]
+          end
           Item(Id(index.to_s), *values)
         end
       end

--- a/src/lib/y2configuration_management/widgets/collection.rb
+++ b/src/lib/y2configuration_management/widgets/collection.rb
@@ -132,8 +132,13 @@ module Y2ConfigurationManagement
       #
       # @param prototype [FormElement] Prototype definition
       def headers_from_prototype(prototype)
-        names = prototype.elements.map { |h| (h.name || h.id) }
-        ids = prototype.elements.map(&:id)
+        els = if prototype.is_a? Salt::Container
+          prototype.elements
+        else
+          [prototype]
+        end
+        names = els.map { |h| (h.name || h.id) }
+        ids = els.map(&:id)
         [names, ids]
       end
     end

--- a/test/fixtures/scalar-collection-dflt.yml
+++ b/test/fixtures/scalar-collection-dflt.yml
@@ -1,0 +1,8 @@
+person:
+  "$type": namespace
+  computers:
+    "$type": edit-group
+    "$prototype":
+      "$type": text
+    "$default":
+      - "ZX Spectrum"

--- a/test/fixtures/scalar-collection.yml
+++ b/test/fixtures/scalar-collection.yml
@@ -1,0 +1,6 @@
+person:
+  "$type": namespace
+  computers:
+    "$type": edit-group
+    "$prototype":
+      "$type": text

--- a/test/y2configuration_management/salt/form_controller_test.rb
+++ b/test/y2configuration_management/salt/form_controller_test.rb
@@ -46,13 +46,25 @@ describe Y2ConfigurationManagement::Salt::FormController do
     allow(Y2ConfigurationManagement::Widgets::FormPopup).to receive(:new).and_return(popup)
   end
 
-  describe "#show_main_dialog" do
-    it "opens the dialog with the whole form" do
-      expect(builder).to receive(:build).with(form.root.elements).and_call_original
-      expect(Yast::CWM).to receive(:show)
-      controller.show_main_dialog
+  shared_examples "form_controller" do
+    describe "#show_main_dialog" do
+      it "opens the dialog with the whole form" do
+        expect(builder).to receive(:build).with(form.root.elements).and_call_original
+        expect(Yast::CWM).to receive(:show)
+        controller.show_main_dialog
+      end
+
+      it "runs the dialog with the whole form" do
+        expect(builder).to receive(:build).with(form.root.elements).and_call_original
+        # Instead of mocking CWM.show we let the CWM preparation a step further,
+        # to catch bugs in widget initialization
+        expect(Yast::UI).to receive(:WaitForEvent).and_return("ID" => :abort)
+        controller.show_main_dialog
+      end
     end
   end
+
+  include_examples "form_controller"
 
   describe "#add" do
     let(:prototype) { form.find_element_by(path: path).prototype }
@@ -126,5 +138,14 @@ describe Y2ConfigurationManagement::Salt::FormController do
       expect(data).to receive(:remove_item).with(".root.person.computers", 1)
       controller.remove(".root.person.computers", 1)
     end
+  end
+
+  context "for a collection of scalars, without $default" do
+    let(:form) do
+      fname = FIXTURES_PATH.join("scalar-collection.yml")
+      Y2ConfigurationManagement::Salt::Form.from_file(fname)
+    end
+
+    include_examples "form_controller"
   end
 end

--- a/test/y2configuration_management/widgets/collection_test.rb
+++ b/test/y2configuration_management/widgets/collection_test.rb
@@ -99,15 +99,8 @@ describe Y2ConfigurationManagement::Widgets::Collection do
 
   context "for a collection of scalars, without $default" do
     let(:form_spec) do
-      Y2ConfigurationManagement::Salt::Form.new(
-        "person" => {
-          "$type" => "namespace",
-          "computers" => {
-            "$type" => "edit-group",
-            "$prototype" => { "$type" => "text" }
-          }
-        }
-      )
+      fname = FIXTURES_PATH.join("scalar-collection.yml")
+      Y2ConfigurationManagement::Salt::Form.from_file(fname)
     end
 
     include_examples "collection"

--- a/test/y2configuration_management/widgets/collection_test.rb
+++ b/test/y2configuration_management/widgets/collection_test.rb
@@ -87,4 +87,29 @@ describe Y2ConfigurationManagement::Widgets::Collection do
       expect(collection.headers).to eq(["Brand", "Number of Disks"])
     end
   end
+
+  shared_examples "collection" do
+    describe ".new" do
+      it "instantiates a new widget according to the spec" do
+        collection = described_class.new(spec, controller)
+        expect(collection.path).to eq(path)
+      end
+    end
+  end
+
+  context "for a collection of scalars, without $default" do
+    let(:form_spec) do
+      Y2ConfigurationManagement::Salt::Form.new(
+        "person" => {
+          "$type" => "namespace",
+          "computers" => {
+            "$type" => "edit-group",
+            "$prototype" => { "$type" => "text" }
+          }
+        }
+      )
+    end
+
+    include_examples "collection"
+  end
 end


### PR DESCRIPTION
I am testing with the SuMa forms and fixing bugs, adding minimal tests. I may add more, but this is ready for review:

Any collection
- [x] fixed a crash if the $default was not specified

For 'scalar collections' which have single values (not groups/dictionaries/hashes) as elements
- [x] displaying them
- [ ] editing them

For hash collections
- [ ] editing the actual value (as opposed to the default)