### PR TITLE
Fix directories precedence

### DIFF
--- a/src/lib/configuration_management/configurations/salt.rb
+++ b/src/lib/configuration_management/configurations/salt.rb
@@ -56,14 +56,14 @@ module Yast
         #
         # @return [Array<Pathname>] Path to Salt state roots
         def states_roots(scope = :local)
-          scoped_paths(@custom_states_roots, scope) + [states_root(scope)]
+          [states_root(scope)] + scoped_paths(@custom_states_roots, scope)
         end
 
         # Return paths to the fromulas root
         #
         # @return [Array<Pathname>] Path to Salt formulas roots
         def formulas_roots(scope = :local)
-          scoped_paths(@custom_formulas_roots) + [formulas_root(scope)]
+          [formulas_root(scope)] + scoped_paths(@custom_formulas_roots)
         end
 
       private

--- a/test/lib/configurations/salt_spec.rb
+++ b/test/lib/configurations/salt_spec.rb
@@ -36,6 +36,27 @@ describe Yast::ConfigurationManagement::Configurations::Salt do
     end
   end
 
+  describe "#states_roots" do
+    let(:profile) do
+      { "states_roots" => [ "/srv/salt" ] }
+    end
+
+    it "returns states roots including custom ones" do
+      expect(config.states_roots).to eq([config.states_root, Pathname.new("/srv/salt")])
+    end
+  end
+
+
+  describe "#formulas_roots" do
+    let(:profile) do
+      { "formulas_roots" => [ "/srv/formulas" ] }
+    end
+
+    it "returns formulas roots including custom ones" do
+      expect(config.formulas_roots).to eq([config.formulas_root, Pathname.new("/srv/formulas")])
+    end
+  end
+
   describe "#enabled_states" do
     it "returns the list of enabled states" do
       expect(config.enabled_states).to eq(["motd"])


### PR DESCRIPTION
Avoids confusing Salt with other `top.sls` files. We experimented this problem with a leftover
`/srv/salt/top.sls` which included some state. The result was that the state was always applied.