### PR TITLE
Rename form "path" (eg. ".root.foo.bar") to "locator"

### DIFF
--- a/src/lib/y2configuration_management/salt/form.rb
+++ b/src/lib/y2configuration_management/salt/form.rb
@@ -92,7 +92,7 @@ module Y2ConfigurationManagement
     #
     # scalar values, groups and collections
     class FormElement
-      PATH_DELIMITER = ".".freeze
+      LOCATOR_DELIMITER = ".".freeze
       # @return [String] the key for the pillar
       attr_reader :id
       # @return [Symbol]
@@ -124,14 +124,14 @@ module Y2ConfigurationManagement
         @parent = parent
       end
 
-      # Return the absolute path of this form element in the actual form
+      # Return the absolute locator of this form element in the actual form
       #
-      # FIXME: possible implementation of the form element path
+      # FIXME: possible implementation of the form element locator
       #
       # @return [String]
-      def path
-        prefix = parent ? parent.path : ""
-        "#{prefix}#{PATH_DELIMITER}#{id}"
+      def locator
+        prefix = parent ? parent.locator : ""
+        "#{prefix}#{LOCATOR_DELIMITER}#{id}"
       end
 
     private
@@ -183,11 +183,11 @@ module Y2ConfigurationManagement
 
       # Recursively looks for a particular {FormElement}
       #
-      # @example look for a FormElement by a specific name, path or id
+      # @example look for a FormElement by a specific name, locator or id
       #
       #   f = Y2ConfigurationManagemenet.from_file("form.yml")
       #   f.find_element_by(name: "subnets") #=> <Collection @name="subnets"
-      #   f.find_element_by(path: ".root.dhcpd") #=> <Container @name="dhcpd"
+      #   f.find_element_by(locator: ".root.dhcpd") #=> <Container @name="dhcpd"
       #   f.find_element_by(id: "hosts") #=> <Container @id="hosts"
       #
       # @param arg [Hash]

--- a/src/lib/y2configuration_management/salt/form_controller.rb
+++ b/src/lib/y2configuration_management/salt/form_controller.rb
@@ -73,39 +73,39 @@ module Y2ConfigurationManagement
 
       # Convenience method for returning the value of a given element
       #
-      # @param path [String] Path to the element
-      # @param index [Integer] Element's index when path refers to a collection
-      def get(path, index = nil)
-        @data.get(path, index)
+      # @param locator [String] Locator of the element
+      # @param index [Integer] Element's index when locator refers to a collection
+      def get(locator, index = nil)
+        @data.get(locator, index)
       end
 
       # Opens a new dialog in order to add a new element to a collection
       #
-      # @param path [String] Collection's path
-      def add(path)
-        result = edit_item(path, nil)
+      # @param locator [String] Collection's locator
+      def add(locator)
+        result = edit_item(locator, nil)
         return if result.nil?
-        @data.add_item(path, result.values.first)
+        @data.add_item(locator, result.values.first)
         refresh_main_form
       end
 
       # Opens a new dialog in order to edit an element within a collection
       #
-      # @param path  [String] Collection's path
+      # @param locator  [String] Collection's locator
       # @param index [Integer] Element's index
-      def edit(path, index)
-        result = edit_item(path, get(path, index))
+      def edit(locator, index)
+        result = edit_item(locator, get(locator, index))
         return if result.nil?
-        @data.update_item(path, index, result.values.first)
+        @data.update_item(locator, index, result.values.first)
         refresh_main_form
       end
 
       # Removes an element from a collection
       #
-      # @param path  [String] Collection's path
+      # @param locator  [String] Collection's locator
       # @param index [Integer] Element's index
-      def remove(path, index)
-        @data.remove_item(path, index)
+      def remove(locator, index)
+        @data.remove_item(locator, index)
         refresh_main_form
       end
 
@@ -131,25 +131,25 @@ module Y2ConfigurationManagement
       def main_form
         return @main_form if @main_form
         @main_form = form_builder.build(form.root.elements)
-        @main_form.value = get(form.root.path)
+        @main_form.value = get(form.root.locator)
         @main_form
       end
 
       # Refreshes the main form content
       def refresh_main_form
-        data.update(form.root.path, main_form.current_values)
-        main_form.refresh(get(form.root.path))
+        data.update(form.root.locator, main_form.current_values)
+        main_form.refresh(get(form.root.locator))
       end
 
       # Displays a form to edit a given item
       #
-      # @param path [String] Collection path
+      # @param locator [String] Collection locator
       # @param item [Object] Item to edit
       # @return [Hash,nil] edited data; `nil` when the user cancels the dialog
-      def edit_item(path, item)
-        element = form.find_element_by(path: path)
+      def edit_item(locator, item)
+        element = form.find_element_by(locator: locator)
         widget_form = form_builder.build(element.prototype)
-        wid = path[1..-1].split(".").last
+        wid = locator[1..-1].split(".").last
         widget_form.value = { wid => item }
         show_popup(element.name, widget_form)
       end
@@ -168,7 +168,7 @@ module Y2ConfigurationManagement
       #   version.
       def next_handler
         main_form.store
-        data.update(form.root.path, main_form.result)
+        data.update(form.root.locator, main_form.result)
         pillar.data = data.to_h.fetch("root", {})
         puts pillar.dump
         true

--- a/src/lib/y2configuration_management/salt/form_data.rb
+++ b/src/lib/y2configuration_management/salt/form_data.rb
@@ -24,7 +24,7 @@ module Y2ConfigurationManagement
     # @todo The support for collections is rather simple and nesting collections is not supported.
     #       We might consider using JSON Patch to modify the data.
     class FormData
-      PATH_DELIMITER = ".".freeze
+      LOCATOR_DELIMITER = ".".freeze
       # @return [Y2ConfigurationManagement::Salt::Form] Form
       attr_reader :form
       # @return [Y2ConfigurationManagement::Salt::Pillar] Pillar
@@ -42,18 +42,18 @@ module Y2ConfigurationManagement
 
       # Returns the value of a given element
       #
-      # @param path [String] Path to the element
-      def get(path, index = nil)
-        value = @data.dig(*path_to_parts(path)) || default_for(path)
+      # @param locator [String] Locator of the element
+      def get(locator, index = nil)
+        value = @data.dig(*locator_to_parts(locator)) || default_for(locator)
         index ? value.at(index) : value
       end
 
       # Updates an element's value
       #
-      # @param path  [String] Path to the collection
+      # @param locator  [String] Locator of the collection
       # @param value [Object] New value
-      def update(path, value)
-        parts = path_to_parts(path)
+      def update(locator, value)
+        parts = locator_to_parts(locator)
         parent_parts = parts[0..-2]
         parent = @data
         parent = parent.dig(* parent_parts) unless parent_parts.empty?
@@ -62,27 +62,27 @@ module Y2ConfigurationManagement
 
       # Adds an element to a collection
       #
-      # @param path  [String] Path to the collection
+      # @param locator  [String] Locator of the collection
       # @param value [Hash] Value to add
-      def add_item(path, value)
-        collection = get(path)
+      def add_item(locator, value)
+        collection = get(locator)
         collection.push(value)
       end
 
-      # @param path  [String]  Path to the collection
+      # @param locator  [String]  Locator of the collection
       # @param index [Integer] Position of the element to remove
       # @param value [Object] New value
-      def update_item(path, index, value)
-        collection = get(path)
+      def update_item(locator, index, value)
+        collection = get(locator)
         collection[index] = value
       end
 
       # Removes an element from a collection
       #
-      # @param path  [String]  Path to the collection
+      # @param locator  [String]  Locator of the collection
       # @param index [Integer] Position of the element to remove
-      def remove_item(path, index)
-        collection = get(path)
+      def remove_item(locator, index)
+        collection = get(locator)
         collection.delete_at(index)
       end
 
@@ -97,17 +97,17 @@ module Y2ConfigurationManagement
 
       # Default value for a given element
       #
-      # @param path [String] Element path
-      def default_for(path)
-        element = form.find_element_by(path: path)
+      # @param locator [String] Element locator
+      def default_for(locator)
+        element = form.find_element_by(locator: locator)
         element ? element.default : nil
       end
 
-      # Split the path into different parts
+      # Split the locator into different parts
       #
-      # @param path [String] Element path
-      def path_to_parts(path)
-        path[1..-1].split(PATH_DELIMITER)
+      # @param locator [String] Element locator
+      def locator_to_parts(locator)
+        locator[1..-1].split(LOCATOR_DELIMITER)
       end
 
       # Builds a hash to keep the form data
@@ -129,8 +129,8 @@ module Y2ConfigurationManagement
           defaults = element.elements.reduce({}) { |a, e| a.merge(data_for_element(e, data)) }
           { element.id => defaults }
         else
-          # TODO: we probably should remove the .root path prefix
-          value = data.dig(*path_to_parts(element.path.gsub(/^\.(root)?/, "")))
+          # TODO: we probably should remove the .root locator prefix
+          value = data.dig(*locator_to_parts(element.locator.gsub(/^\.(root)?/, "")))
           { element.id => value.nil? ? element.default : value }
         end
       end

--- a/src/lib/y2configuration_management/widgets/boolean.rb
+++ b/src/lib/y2configuration_management/widgets/boolean.rb
@@ -28,8 +28,8 @@ module Y2ConfigurationManagement
       attr_reader :label
       # @return [Boolean] Default value
       attr_reader :default
-      # @return [String] Form path
-      attr_reader :path
+      # @return [String] Form locator
+      attr_reader :locator
       # @return [String] Form element id
       attr_reader :id
 
@@ -41,7 +41,7 @@ module Y2ConfigurationManagement
         @label = spec.label
         @default = spec.default == true # nil -> false
         @controller = controller
-        @path = spec.path
+        @locator = spec.locator
         @id = spec.id
         self.widget_id = "boolean:#{spec.id}"
       end

--- a/src/lib/y2configuration_management/widgets/collection.rb
+++ b/src/lib/y2configuration_management/widgets/collection.rb
@@ -27,7 +27,7 @@ module Y2ConfigurationManagement
     # This widget uses a table to display a collection of elements and offers
     # buttons to add, remove and edit them.
     class Collection < ::CWM::CustomWidget
-      attr_reader :label, :min_items, :max_items, :controller, :path, :id, :headers
+      attr_reader :label, :min_items, :max_items, :controller, :locator, :id, :headers
 
       # @return [Array<String>] Headers for the collection table
       attr_reader :headers
@@ -45,7 +45,7 @@ module Y2ConfigurationManagement
         @min_items = spec.min_items
         @max_items = spec.max_items
         @controller = controller
-        @path = spec.path # form element path
+        @locator = spec.locator # form element locator
         @id = spec.id
         @headers, @headers_ids = headers_from_prototype(spec.prototype)
         self.widget_id = "collection:#{spec.id}"
@@ -58,7 +58,7 @@ module Y2ConfigurationManagement
       def contents
         VBox(
           Table(
-            Id("table:#{path}"),
+            Id("table:#{locator}"),
             Opt(:notify, :immediate),
             Header(*headers),
             []
@@ -76,7 +76,7 @@ module Y2ConfigurationManagement
       #
       # @param items_list [Array<Hash>] Collection items
       def value=(items_list)
-        Yast::UI.ChangeWidget(Id("table:#{path}"), :Items, format_items(items_list))
+        Yast::UI.ChangeWidget(Id("table:#{locator}"), :Items, format_items(items_list))
         @value = items_list
       end
 
@@ -95,11 +95,11 @@ module Y2ConfigurationManagement
       def handle(event)
         case event["ID"]
         when "#{widget_id}_add".to_sym
-          controller.add(path)
+          controller.add(locator)
         when "#{widget_id}_edit".to_sym
-          controller.edit(path, selected_row) if selected_row
+          controller.edit(locator, selected_row) if selected_row
         when "#{widget_id}_remove".to_sym
-          controller.remove(path, selected_row) if selected_row
+          controller.remove(locator, selected_row) if selected_row
         end
 
         nil
@@ -114,7 +114,7 @@ module Y2ConfigurationManagement
       #
       # @return [Integer,nil] Index of the selected row or nil if no row is selected
       def selected_row
-        row_id = Yast::UI.QueryWidget(Id("table:#{path}"), :CurrentItem)
+        row_id = Yast::UI.QueryWidget(Id("table:#{locator}"), :CurrentItem)
         row_id ? row_id.to_i : nil
       end
 

--- a/src/lib/y2configuration_management/widgets/group.rb
+++ b/src/lib/y2configuration_management/widgets/group.rb
@@ -25,8 +25,8 @@ module Y2ConfigurationManagement
     class Group < ::CWM::CustomWidget
       # @return [String] Widget label
       attr_reader :label
-      # @return [String] Form element path
-      attr_reader :path
+      # @return [String] Form element locator
+      attr_reader :locator
       # @return [Array<CWM::AbstractWidget>] Widgets which are included in the group
       attr_reader :children
       attr_reader :id
@@ -41,7 +41,7 @@ module Y2ConfigurationManagement
         @label = spec.label
         @children = children
         @controller = controller
-        @path = spec.path
+        @locator = spec.locator
         @id = spec.id
         self.widget_id = "group:#{spec.id}"
       end

--- a/src/lib/y2configuration_management/widgets/select.rb
+++ b/src/lib/y2configuration_management/widgets/select.rb
@@ -29,8 +29,8 @@ module Y2ConfigurationManagement
       attr_reader :items
       # @return [String,nil] Default value
       attr_reader :default
-      # @return [String] Form element path
-      attr_reader :path
+      # @return [String] Form element locator
+      attr_reader :locator
       # @return [String] Form element id
       attr_reader :id
 
@@ -42,7 +42,7 @@ module Y2ConfigurationManagement
         @label = spec.label
         @items = spec.values.map { |v| [v, v] }
         @default = spec.default
-        @path = spec.path
+        @locator = spec.locator
         @id = spec.id
         @controller = controller
         self.widget_id = "select:#{spec.id}"

--- a/src/lib/y2configuration_management/widgets/text.rb
+++ b/src/lib/y2configuration_management/widgets/text.rb
@@ -28,8 +28,8 @@ module Y2ConfigurationManagement
       attr_reader :label
       # @return [String] Default value
       attr_reader :default
-      # @return [String] Form path
-      attr_reader :path
+      # @return [String] Form locator
+      attr_reader :locator
       # @return [String] Form element id
       attr_reader :id
 
@@ -41,7 +41,7 @@ module Y2ConfigurationManagement
         @label = spec.label
         @default = spec.default.to_s
         @controller = controller
-        @path = spec.path
+        @locator = spec.locator
         @id = spec.id
         self.widget_id = "text:#{spec.id}"
       end

--- a/test/y2configuration_management/salt/form_builder_test.rb
+++ b/test/y2configuration_management/salt/form_builder_test.rb
@@ -27,39 +27,39 @@ describe Y2ConfigurationManagement::Salt::FormBuilder do
   let(:form) do
     Y2ConfigurationManagement::Salt::Form.from_file(FIXTURES_PATH.join("form.yml"))
   end
-  let(:element) { form.find_element_by(path: path) }
+  let(:element) { form.find_element_by(locator: locator) }
   let(:controller) { instance_double(Y2ConfigurationManagement::Salt::FormController) }
 
   describe "#build" do
     context "when an input form element is given" do
-      let(:path) { ".root.person.name" }
+      let(:locator) { ".root.person.name" }
 
       it "returns a form containing a text widget" do
         form = builder.build(element)
         expect(form.children).to be_all(Y2ConfigurationManagement::Widgets::Text)
         expect(form.children).to contain_exactly(
           an_object_having_attributes(
-            "path" => ".root.person.name"
+            "locator" => ".root.person.name"
           )
         )
       end
     end
 
     context "when a group form element is given" do
-      let(:path) { ".root.person.address" }
+      let(:locator) { ".root.person.address" }
 
       it "returns a form containing a group widgets" do
         form = builder.build(element)
         group = form.children.first
         expect(group.children).to contain_exactly(
-          an_object_having_attributes("path" => ".root.person.address.street"),
-          an_object_having_attributes("path" => ".root.person.address.country")
+          an_object_having_attributes("locator" => ".root.person.address.street"),
+          an_object_having_attributes("locator" => ".root.person.address.country")
         )
       end
     end
 
     context "when a collection is given" do
-      let(:path) { ".root.person.computers" }
+      let(:locator) { ".root.person.computers" }
 
       it "returns a form containing a collection widget" do
         form = builder.build(element)

--- a/test/y2configuration_management/salt/form_controller_test.rb
+++ b/test/y2configuration_management/salt/form_controller_test.rb
@@ -34,7 +34,7 @@ describe Y2ConfigurationManagement::Salt::FormController do
 
   let(:builder) { Y2ConfigurationManagement::Salt::FormBuilder.new(controller) }
   let(:data) { Y2ConfigurationManagement::Salt::FormData.new(form, pillar) }
-  let(:path) { ".root.person.computers" }
+  let(:locator) { ".root.person.computers" }
   let(:popup) { instance_double(Y2ConfigurationManagement::Widgets::FormPopup, run: nil) }
   let(:widget) do
     instance_double(Y2ConfigurationManagement::Widgets::Form, result: result, "value=" => nil)
@@ -70,7 +70,7 @@ describe Y2ConfigurationManagement::Salt::FormController do
   include_examples "form_controller"
 
   describe "#add" do
-    let(:prototype) { form.find_element_by(path: path).prototype }
+    let(:prototype) { form.find_element_by(locator: locator).prototype }
 
     before do
       allow(Y2ConfigurationManagement::Widgets::FormPopup)
@@ -81,15 +81,15 @@ describe Y2ConfigurationManagement::Salt::FormController do
 
     it "opens the dialog using the collections's prototype" do
       expect(builder).to receive(:build).with(prototype).and_return(widget)
-      controller.add(path)
+      controller.add(locator)
     end
 
     context "when the user accepts the dialog" do
       let(:result) { { "computers" =>  { "brand" => "Lenovo", "disks" => 2 } } }
 
       it "updates the form data" do
-        expect(data).to receive(:add_item).with(path, "brand" => "Lenovo", "disks" => 2)
-        controller.add(path)
+        expect(data).to receive(:add_item).with(locator, "brand" => "Lenovo", "disks" => 2)
+        controller.add(locator)
       end
     end
 
@@ -98,14 +98,14 @@ describe Y2ConfigurationManagement::Salt::FormController do
 
       it "does not modify form data" do
         expect(data).to_not receive(:add_item)
-        controller.add(path)
+        controller.add(locator)
       end
     end
   end
 
   describe "#edit" do
     let(:result) { nil }
-    let(:prototype) { form.find_element_by(path: path).prototype }
+    let(:prototype) { form.find_element_by(locator: locator).prototype }
 
     before do
       allow(builder).to receive(:build).and_call_original
@@ -114,15 +114,15 @@ describe Y2ConfigurationManagement::Salt::FormController do
 
     it "opens the dialog using the collections's prototype" do
       expect(builder).to receive(:build).with(prototype).and_return(widget)
-      controller.edit(path, 0)
+      controller.edit(locator, 0)
     end
 
     context "when the user accepts the dialog" do
       let(:result) { { "computers" =>  { "brand" => "Lenovo", "disks" => 2 } } }
 
       it "updates the form data" do
-        expect(data).to receive(:update_item).with(path, 0, "brand" => "Lenovo", "disks" => 2)
-        controller.edit(path, 0)
+        expect(data).to receive(:update_item).with(locator, 0, "brand" => "Lenovo", "disks" => 2)
+        controller.edit(locator, 0)
       end
     end
 
@@ -131,7 +131,7 @@ describe Y2ConfigurationManagement::Salt::FormController do
 
       it "does not modify form data" do
         expect(data).to_not receive(:update_item)
-        controller.edit(path, 0)
+        controller.edit(locator, 0)
       end
     end
   end

--- a/test/y2configuration_management/salt/form_data_test.rb
+++ b/test/y2configuration_management/salt/form_data_test.rb
@@ -52,7 +52,7 @@ describe Y2ConfigurationManagement::Salt::FormData do
       end
     end
 
-    context "when a collection path and an index is given" do
+    context "when a collection locator and an index is given" do
       it "returns the item in the given position" do
         expect(form_data.get(".root.person.computers", 0)).to eq("brand" => "ACME", "disks" => 1)
       end

--- a/test/y2configuration_management/salt/form_test.rb
+++ b/test/y2configuration_management/salt/form_test.rb
@@ -37,12 +37,12 @@ describe Y2ConfigurationManagement::Salt::Form do
 
   describe "#find_element_by" do
     it "returns the FormElment which match a given argument" do
-      expect(form.find_element_by(path: ".root.demo.system.text"))
+      expect(form.find_element_by(locator: ".root.demo.system.text"))
         .to be_a(Y2ConfigurationManagement::Salt::FormInput)
 
       number = form.find_element_by(name: "Number")
       expect(number).to be_a(Y2ConfigurationManagement::Salt::FormInput)
-      expect(number.path).to eql(".root.demo.number")
+      expect(number.locator).to eql(".root.demo.number")
       expect(form.find_element_by(id: "root"))
         .to be_a(Y2ConfigurationManagement::Salt::Container)
     end
@@ -93,15 +93,15 @@ end
 describe Y2ConfigurationManagement::Salt::FormElement do
   include_examples "Y2ConfigurationManagement::Salt::FormElement"
 
-  describe "#path" do
+  describe "#locator" do
     let(:file_path) { FIXTURES_PATH.join("form.yml") }
-    let(:path_form) { Y2ConfigurationManagement::Salt::Form.from_file(file_path) }
+    let(:locator_form) { Y2ConfigurationManagement::Salt::Form.from_file(file_path) }
 
-    it "returns the absolute form element path in the Form" do
-      computers_collection = path_form.find_element_by(id: "computers")
-      expect(computers_collection.path).to eql(".root.person.computers")
+    it "returns the absolute form element locator in the Form" do
+      computers_collection = locator_form.find_element_by(id: "computers")
+      expect(computers_collection.locator).to eql(".root.person.computers")
       brand = computers_collection.prototype.find_element_by(id: "brand")
-      expect(brand.path).to eql(".root.person.computers.computers.brand")
+      expect(brand.locator).to eql(".root.person.computers.computers.brand")
     end
   end
 end

--- a/test/y2configuration_management/widgets/boolean_test.rb
+++ b/test/y2configuration_management/widgets/boolean_test.rb
@@ -31,14 +31,14 @@ describe Y2ConfigurationManagement::Widgets::Boolean do
   let(:form_spec) do
     Y2ConfigurationManagement::Salt::Form.from_file(FIXTURES_PATH.join("form.yml"))
   end
-  let(:spec) { form_spec.find_element_by(path: path) }
-  let(:path) { ".root.person.wants_newsletter" }
+  let(:spec) { form_spec.find_element_by(locator: locator) }
+  let(:locator) { ".root.person.wants_newsletter" }
   let(:controller) { instance_double(Y2ConfigurationManagement::Salt::FormController) }
 
   describe ".new" do
     it "instantiates a new widget according to the spec" do
       widget = described_class.new(spec, controller)
-      expect(widget.path).to eq(path)
+      expect(widget.locator).to eq(locator)
       expect(widget.default).to eq(true)
     end
   end
@@ -51,7 +51,7 @@ describe Y2ConfigurationManagement::Widgets::Boolean do
 
     context "when no default value was given" do
       let(:spec) do
-        sp = form_spec.find_element_by(path: path)
+        sp = form_spec.find_element_by(locator: locator)
         sp.instance_variable_set(:@default, nil)
         sp
       end

--- a/test/y2configuration_management/widgets/collection_test.rb
+++ b/test/y2configuration_management/widgets/collection_test.rb
@@ -34,8 +34,8 @@ describe Y2ConfigurationManagement::Widgets::Collection do
   let(:form_spec) do
     Y2ConfigurationManagement::Salt::Form.from_file(FIXTURES_PATH.join("form.yml"))
   end
-  let(:spec) { form_spec.find_element_by(path: path) }
-  let(:path) { ".root.person.computers" }
+  let(:spec) { form_spec.find_element_by(locator: locator) }
+  let(:locator) { ".root.person.computers" }
   let(:controller) { instance_double(Y2ConfigurationManagement::Salt::FormController) }
   let(:formatted_default) do
     [
@@ -46,7 +46,7 @@ describe Y2ConfigurationManagement::Widgets::Collection do
   describe ".new" do
     it "instantiates a new widget according to the spec" do
       collection = described_class.new(spec, controller)
-      expect(collection.path).to eq(path)
+      expect(collection.locator).to eq(locator)
       expect(collection.min_items).to eq(1)
       expect(collection.max_items).to eq(4)
     end
@@ -57,7 +57,7 @@ describe Y2ConfigurationManagement::Widgets::Collection do
       let(:event) { { "ID" => "#{collection.widget_id}_add".to_sym } }
 
       it "adds a new element to the collection" do
-        expect(controller).to receive(:add).with(path)
+        expect(controller).to receive(:add).with(locator)
         collection.handle(event)
       end
     end
@@ -70,7 +70,7 @@ describe Y2ConfigurationManagement::Widgets::Collection do
       end
 
       it "edits an element of the collection" do
-        expect(controller).to receive(:edit).with(path, 1)
+        expect(controller).to receive(:edit).with(locator, 1)
         collection.handle(event)
       end
     end
@@ -83,7 +83,7 @@ describe Y2ConfigurationManagement::Widgets::Collection do
       end
 
       it "removes the selected element from the collection" do
-        expect(controller).to receive(:remove).with(path, 1)
+        expect(controller).to receive(:remove).with(locator, 1)
         collection.handle(event)
       end
     end
@@ -99,7 +99,7 @@ describe Y2ConfigurationManagement::Widgets::Collection do
     describe ".new" do
       it "instantiates a new widget according to the spec" do
         collection = described_class.new(spec, controller)
-        expect(collection.path).to eq(path)
+        expect(collection.locator).to eq(locator)
       end
     end
 

--- a/test/y2configuration_management/widgets/group_test.rb
+++ b/test/y2configuration_management/widgets/group_test.rb
@@ -32,15 +32,15 @@ describe Y2ConfigurationManagement::Widgets::Group do
   let(:form_spec) do
     Y2ConfigurationManagement::Salt::Form.from_file(FIXTURES_PATH.join("form.yml"))
   end
-  let(:spec) { form_spec.find_element_by(path: path) }
-  let(:path) { ".root.person.address" }
+  let(:spec) { form_spec.find_element_by(locator: locator) }
+  let(:locator) { ".root.person.address" }
   let(:controller) { instance_double(Y2ConfigurationManagement::Salt::FormController) }
   let(:widget1) { instance_double(Y2ConfigurationManagement::Widgets::Text, id: "widget1") }
 
   describe ".new" do
     it "instantiates a new widget according to the spec" do
       group = described_class.new(spec, [widget1], controller)
-      expect(group.path).to eq(path)
+      expect(group.locator).to eq(locator)
     end
   end
 

--- a/test/y2configuration_management/widgets/select_test.rb
+++ b/test/y2configuration_management/widgets/select_test.rb
@@ -31,14 +31,14 @@ describe Y2ConfigurationManagement::Widgets::Select do
   let(:form_spec) do
     Y2ConfigurationManagement::Salt::Form.from_file(FIXTURES_PATH.join("form.yml"))
   end
-  let(:spec) { form_spec.find_element_by(path: path) }
-  let(:path) { ".root.person.address.country" }
+  let(:spec) { form_spec.find_element_by(locator: locator) }
+  let(:locator) { ".root.person.address.country" }
   let(:controller) { instance_double(Y2ConfigurationManagement::Salt::FormController) }
 
   describe ".new" do
     it "instantiates a new widget according to the spec" do
       selector = described_class.new(spec, controller)
-      expect(selector.path).to eq(path)
+      expect(selector.locator).to eq(locator)
       expect(selector.items)
         .to eq([["Czech Republic", "Czech Republic"], ["Germany", "Germany"], ["Spain", "Spain"]])
       expect(selector.default).to eq("Czech Republic")
@@ -53,7 +53,7 @@ describe Y2ConfigurationManagement::Widgets::Select do
 
     context "when no default value was given" do
       let(:spec) do
-        sp = form_spec.find_element_by(path: path)
+        sp = form_spec.find_element_by(locator: locator)
         sp.instance_variable_set(:@default, nil)
         sp
       end

--- a/test/y2configuration_management/widgets/text_test.rb
+++ b/test/y2configuration_management/widgets/text_test.rb
@@ -31,14 +31,14 @@ describe Y2ConfigurationManagement::Widgets::Text do
   let(:form_spec) do
     Y2ConfigurationManagement::Salt::Form.from_file(FIXTURES_PATH.join("form.yml"))
   end
-  let(:spec) { form_spec.find_element_by(path: path) }
-  let(:path) { ".root.person.name" }
+  let(:spec) { form_spec.find_element_by(locator: locator) }
+  let(:locator) { ".root.person.name" }
   let(:controller) { instance_double(Y2ConfigurationManagement::Salt::FormController) }
 
   describe ".new" do
     it "instantiates a new widget according to the spec" do
       text = described_class.new(spec, controller)
-      expect(text.path).to eq(path)
+      expect(text.locator).to eq(locator)
       expect(text.default).to eq("John Doe")
     end
   end
@@ -51,7 +51,7 @@ describe Y2ConfigurationManagement::Widgets::Text do
 
     context "when no default value was given" do
       let(:spec) do
-        sp = form_spec.find_element_by(path: path)
+        sp = form_spec.find_element_by(locator: locator)
         sp.instance_variable_set(:@default, nil)
         sp
       end


### PR DESCRIPTION
To distinguish it from filesystem paths (sometimes Pathname, sometimes String)
and Yast::Path

So far this is only renaming, the data type remains String. This already helps a lot.