### PR TITLE
Fix Select Widget initialization value

### DIFF
--- a/src/lib/y2configuration_management/widgets/select.rb
+++ b/src/lib/y2configuration_management/widgets/select.rb
@@ -48,11 +48,17 @@ module Y2ConfigurationManagement
         self.widget_id = "select:#{spec.id}"
       end
 
+      # Workaround for modifying the current value. It modifies also the
+      # default value for initializing it correctly when no value is defined
+      def value=(value)
+        @default = value
+        super
+      end
+
       # @see CWM::AbstractWidget
       def init
-        return if default.nil? || !value.nil?
-        item = items.find { |_i, v| v == default }
-        self.value = item.first if item
+        return if default.nil?
+        self.value = default
       end
 
     private

--- a/test/y2configuration_management/widgets/select_test.rb
+++ b/test/y2configuration_management/widgets/select_test.rb
@@ -64,4 +64,12 @@ describe Y2ConfigurationManagement::Widgets::Select do
       end
     end
   end
+
+  describe "#value=" do
+    it "modifies the default value with the value given" do
+      expect(selector.default).to_not eql("Spain")
+      selector.value = "Spain"
+      expect(selector.default).to eql("Spain")
+    end
+  end
 end


### PR DESCRIPTION
- It fixes the default value for new elements, and also respect the current value when editing.