### PR TITLE
Fix cancel

### DIFF
--- a/src/lib/y2configuration_management/salt/form_controller.rb
+++ b/src/lib/y2configuration_management/salt/form_controller.rb
@@ -150,7 +150,7 @@ module Y2ConfigurationManagement
       # @param widget [Array<CWM::AbstractWidget>] Popup content (as an array of CWM widgets)
       # @return [Hash,nil] Dialog's result
       def show_popup(widget)
-        Widgets::FormPopup.new(widget.title, widget).run
+        return unless Widgets::FormPopup.new(widget.title, widget).run == :ok
         widget.result
       end
 

--- a/src/lib/y2configuration_management/widgets/form_popup.rb
+++ b/src/lib/y2configuration_management/widgets/form_popup.rb
@@ -41,6 +41,12 @@ module Y2ConfigurationManagement
       def contents
         VBox(@inner_content)
       end
+
+    private
+
+      def buttons
+        [ok_button, cancel_button]
+      end
     end
   end
 end

--- a/test/y2configuration_management/salt/form_controller_test.rb
+++ b/test/y2configuration_management/salt/form_controller_test.rb
@@ -36,7 +36,8 @@ describe Y2ConfigurationManagement::Salt::FormController do
   let(:data) { Y2ConfigurationManagement::Salt::FormData.from_pillar(form, pillar) }
   let(:locator) { locator_from_string(".root.person.computers") }
   let(:collection_locator) { locator_from_string(".person.computers") }
-  let(:popup) { instance_double(Y2ConfigurationManagement::Widgets::FormPopup, run: nil) }
+  let(:popup) { instance_double(Y2ConfigurationManagement::Widgets::FormPopup, run: popup_run) }
+  let(:popup_run) { :ok }
   let(:widget) do
     instance_double(Y2ConfigurationManagement::Widgets::Form, result: result).as_null_object
   end
@@ -119,6 +120,7 @@ describe Y2ConfigurationManagement::Salt::FormController do
 
     context "when the user cancels the dialog" do
       let(:result) { nil }
+      let(:popup_run) { :cancel }
 
       it "does not modify form data" do
         expect(data).to_not receive(:add_item)
@@ -177,7 +179,8 @@ describe Y2ConfigurationManagement::Salt::FormController do
     end
 
     context "when the user cancels the dialog" do
-      let(:result) { nil }
+      let(:result) { { "brand" => "Lenovo", "disks" => [] } }
+      let(:popup_run) { :cancel }
 
       it "does not modify form data" do
         expect(data).to_not receive(:update).with(locator, anything)


### PR DESCRIPTION
- Only return the widget result when clicking the :ok: button
- There is no help in form popups so basically the :help button is useless (removed)