### PR TITLE
Improve form element locator parsing

### DIFF
--- a/src/lib/y2configuration_management/salt/form_element_locator.rb
+++ b/src/lib/y2configuration_management/salt/form_element_locator.rb
@@ -54,7 +54,7 @@ module Y2ConfigurationManagement
         # @param string [String] String representing an element locator
         # @return [FormElementLocator]
         def from_string(string)
-          parts = string[1..-1].split(".").each_with_object([]) do |part, all|
+          parts = string[1..-1].scan(/(?:\[.*?\]|[^\.])+/).each_with_object([]) do |part, all|
             all.concat(from_part(part))
           end
           new(parts)

--- a/src/lib/y2configuration_management/salt/form_element_locator.rb
+++ b/src/lib/y2configuration_management/salt/form_element_locator.rb
@@ -54,7 +54,7 @@ module Y2ConfigurationManagement
         # @param string [String] String representing an element locator
         # @return [FormElementLocator]
         def from_string(string)
-          parts = string[1..-1].scan(/(?:\[.*?\]|[^\.])+/).each_with_object([]) do |part, all|
+          parts = string[1..-1].scan(/(?:\[.*?\]|[^\.\[])+/).each_with_object([]) do |part, all|
             all.concat(from_part(part))
           end
           new(parts)
@@ -63,7 +63,7 @@ module Y2ConfigurationManagement
       private
 
         # @return [Regexp] Regular expression representing a locator part
-        INDEXED_PART = /\A(\w+)\[(.+)\]\z/
+        INDEXED_PART = /\A([^\[]+)\[(.+)\]\z/
 
         # Parses a locator part
         #
@@ -72,8 +72,11 @@ module Y2ConfigurationManagement
         def from_part(string)
           match = INDEXED_PART.match(string)
           return [string.to_sym] unless match
-          path, id = match[1..-1]
-          numeric_id?(id) ? [path.to_sym, id.to_i] : [path.to_sym, id]
+          path = match[1]
+          ids = match[2].split("][").map do |id|
+            numeric_id?(id) ? id.to_i : id
+          end
+          [path.to_sym] + ids
         end
 
         # Determines whether the id is numeric or not

--- a/test/y2configuration_management/salt/form_element_locator_test.rb
+++ b/test/y2configuration_management/salt/form_element_locator_test.rb
@@ -33,6 +33,15 @@ describe Y2ConfigurationManagement::Salt::FormElementLocator do
         [:root, :person, :computers, 2, :interfaces, "eth0"]
       )
     end
+
+    context "when a index containing points is given" do
+      it "keeps those points" do
+        locator = described_class.from_string(".root.domains[example.net]")
+        expect(locator.parts).to eq(
+          [:root, :domains, "example.net"]
+        )
+      end
+    end
   end
 
   describe "#to_s" do

--- a/test/y2configuration_management/salt/form_element_locator_test.rb
+++ b/test/y2configuration_management/salt/form_element_locator_test.rb
@@ -42,6 +42,15 @@ describe Y2ConfigurationManagement::Salt::FormElementLocator do
         )
       end
     end
+
+    context "when a index containing indexes together" do
+      it "extracts all the indexes" do
+        locator = described_class.from_string(".root.domains[example.net][0]")
+        expect(locator.parts).to eq(
+          [:root, :domains, "example.net", 0]
+        )
+      end
+    end
   end
 
   describe "#to_s" do


### PR DESCRIPTION
#51 was merged against the wrong branch (`salt-forms-support-ng` is supposed to be already merged and closed). Trying to merge now onto the correct one.