### PR TITLE
Simplify FormController by not tracking current action

### DIFF
--- a/src/lib/y2configuration_management/salt/form_controller.rb
+++ b/src/lib/y2configuration_management/salt/form_controller.rb
@@ -210,8 +210,9 @@ module Y2ConfigurationManagement
       def find_or_create_item(item_locator)
         new_item = get(item_locator)
         return new_item if new_item
-        form_data.add_item(item_locator.parent, {})
-        {}
+        new_item = {}
+        form_data.add_item(item_locator.parent, new_item)
+        new_item
       end
 
       # Determines the locator for an element which is about to be created

--- a/src/lib/y2configuration_management/salt/form_controller_state.rb
+++ b/src/lib/y2configuration_management/salt/form_controller_state.rb
@@ -34,21 +34,18 @@ module Y2ConfigurationManagement
       def initialize(data)
         @form_widgets = []
         @locators = []
-        @actions = []
         @form_data_snapshots = [data]
       end
 
       # Registers that a new form has been open
       #
-      # It stores relevant information (the action, the locator and the form).
+      # It stores relevant information (the current locator and the form).
       #
-      # @param action      [Symbol] Action which triggered the form (:add or :edit)
       # @param locator     [FormElementLocator] Form element locator
       # @param form_widget [Widgets::Form] Form widget
-      def open_form(action, locator, form_widget)
+      def open_form(locator, form_widget)
         @form_widgets << form_widget
         @locators << locator
-        @actions << action
         backup_data
       end
 
@@ -59,13 +56,6 @@ module Y2ConfigurationManagement
         @form_widgets.last
       end
 
-      # Current action
-      #
-      # @return [Symbol] :add or :edit
-      def action
-        @actions.last
-      end
-
       # Locator of the current form widget
       #
       # @return [FormElementLocator]
@@ -73,20 +63,10 @@ module Y2ConfigurationManagement
         @locators.last
       end
 
-      # Replaces the current action/locator
-      #
-      # @param new_action  [Symbol]
-      # @param new_locator [FormElementLocator]
-      def replace(new_action, new_locator)
-        @actions[-1] = new_action
-        @locators[-1] = new_locator
-      end
-
       # Removes the information related to the most recently open form widget
       def close_form(rollback: false)
         @form_widgets.pop
         @locators.pop
-        @actions.pop
         if rollback
           restore_backup
         else

--- a/test/y2configuration_management/salt/form_controller_state_test.rb
+++ b/test/y2configuration_management/salt/form_controller_state_test.rb
@@ -38,21 +38,19 @@ describe Y2ConfigurationManagement::Salt::FormControllerState do
   let(:data) { Y2ConfigurationManagement::Salt::FormData.from_pillar(form, pillar) }
 
   describe "#open_form" do
-    it "sets action, locator and element" do
-      state.open_form(:add, locator, form_widget)
-      expect(state.action).to eq(:add)
+    it "sets locator and element" do
+      state.open_form(locator, form_widget)
       expect(state.form_widget).to eq(form_widget)
       expect(state.locator).to eq(locator)
     end
 
     context "when a form is already open" do
       before do
-        state.open_form(:add, locator, form_widget)
+        state.open_form(locator, form_widget)
       end
 
       it "adds the information of the new form" do
-        state.open_form(:edit, locator_1, form_widget_1)
-        expect(state.action).to eq(:edit)
+        state.open_form(locator_1, form_widget_1)
         expect(state.locator).to eq(locator_1)
         expect(state.form_widget).to eq(form_widget_1)
       end
@@ -61,13 +59,13 @@ describe Y2ConfigurationManagement::Salt::FormControllerState do
 
   describe "#close_form" do
     before do
-      state.open_form(:add, locator, form_widget)
-      state.open_form(:edit, locator_1, form_widget_1)
+      state.open_form(locator, form_widget)
+      state.open_form(locator_1, form_widget_1)
     end
 
     it "removes the information of the most recent form" do
       state.close_form
-      expect(state.action).to eq(:add)
+      expect(state.locator).to eq(locator)
     end
 
     context "when asked for rollback" do

--- a/test/y2configuration_management/salt/form_controller_test.rb
+++ b/test/y2configuration_management/salt/form_controller_test.rb
@@ -50,7 +50,7 @@ describe Y2ConfigurationManagement::Salt::FormController do
     allow(Y2ConfigurationManagement::Salt::FormBuilder).to receive(:new)
       .with(controller).and_return(builder)
     allow(Y2ConfigurationManagement::Widgets::FormPopup).to receive(:new).and_return(popup)
-    state.open_form(:edit, form.root.locator, builder.build(form.root))
+    state.open_form(form.root.locator, builder.build(form.root))
   end
 
   shared_examples "form_controller" do
@@ -131,14 +131,15 @@ describe Y2ConfigurationManagement::Salt::FormController do
     context "adding an element to a nested collection" do
       let(:parent_form) do
         instance_double(
-          Y2ConfigurationManagement::Widgets::Form, result: { "brand" => "Lenovo", "disks" => [] }
+          Y2ConfigurationManagement::Widgets::Form, result: { "brand" => "ACME", "disks" => [] }
         ).as_null_object
       end
 
+      let(:parent_locator) { locator_from_string(".root.person.computers[0]") }
+
       before do
         allow(builder).to receive(:build).and_return(widget)
-        allow(data).to receive(:add_item).and_call_original
-        state.open_form(:add, locator_from_string(".root.person.computers"), parent_form)
+        state.open_form(parent_locator, parent_form)
       end
 
       context "when the user accepts the dialog" do
@@ -147,7 +148,7 @@ describe Y2ConfigurationManagement::Salt::FormController do
 
         it "updates the form data" do
           controller.add(collection_locator)
-          collection = controller.get(locator_from_string(".root.person.computers[2].disks"))
+          collection = controller.get(parent_locator.join(collection_locator))
           expect(collection).to eq([result])
         end
       end
@@ -198,7 +199,7 @@ describe Y2ConfigurationManagement::Salt::FormController do
       before do
         allow(builder).to receive(:build).and_return(widget)
         allow(data).to receive(:update).and_call_original
-        state.open_form(:edit, locator_from_string(".root.person.computers[1]"), parent_form)
+        state.open_form(locator_from_string(".root.person.computers[1]"), parent_form)
       end
 
       context "when the user accepts the dialog" do


### PR DESCRIPTION
Always add nested elements and trust in the backup/restore mechanism.