### PR TITLE
Firstboot support improvements

### DIFF
--- a/src/lib/y2configuration_management/clients/main.rb
+++ b/src/lib/y2configuration_management/clients/main.rb
@@ -62,7 +62,8 @@ module Y2ConfigurationManagement
         log.info("Provisioning Configuration Management")
         config = Y2ConfigurationManagement::Configurations::Base.import(settings)
         configurator = Y2ConfigurationManagement::Configurators::Base.for(config)
-        return :abort unless configurator.prepare
+        ret = configurator.prepare
+        return ret unless ret == :finish
         if !Yast::PackageSystem.CheckAndInstallPackages(configurator.packages.fetch("install", []))
           return :abort
         end

--- a/src/lib/y2configuration_management/configurators/base.rb
+++ b/src/lib/y2configuration_management/configurators/base.rb
@@ -111,10 +111,11 @@ module Y2ConfigurationManagement
       # control is passed to the required configurator. See mode definitions
       # in the given configurator.
       #
+      # @param opts [Hash] Configurator options
       # @see .mode
-      def prepare
+      def prepare(opts = {})
         ::FileUtils.mkdir_p(config.work_dir) if mode?(:masterless)
-        send("prepare_#{config.mode}")
+        send("prepare_#{config.mode}", opts)
       end
 
       # Determines whether the configurator is operating in the given module

--- a/src/lib/y2configuration_management/configurators/base.rb
+++ b/src/lib/y2configuration_management/configurators/base.rb
@@ -112,6 +112,10 @@ module Y2ConfigurationManagement
       # in the given configurator.
       #
       # @param opts [Hash] Configurator options
+      # @return [Symbol] :finish when configuration was successful; :back when the user
+      #   asked to go back and configuration did not finihed; :abort when configuration
+      #   failed or was aborted.
+      #
       # @see .mode
       def prepare(opts = {})
         ::FileUtils.mkdir_p(config.work_dir) if mode?(:masterless)

--- a/src/lib/y2configuration_management/configurators/puppet.rb
+++ b/src/lib/y2configuration_management/configurators/puppet.rb
@@ -27,14 +27,18 @@ module Y2ConfigurationManagement
       PRIVATE_KEY_BASE_PATH = "/var/lib/puppet/ssl/private_keys".freeze
       PUBLIC_KEY_BASE_PATH = "/var/lib/puppet/ssl/public_keys".freeze
 
+      # @return [Symbol] :finish when configuration was successful; :back when the user
+      #   :abort when configuration failed or was aborted.
       mode(:masterless) do |_opts|
         update_configuration
-        fetch_config(config.modules_url, config.work_dir)
+        fetch_config(config.modules_url, config.work_dir) ? :finish : :abort
       end
 
+      # @return [Symbol] :finish when configuration was successful; :abort when configuration failed
+      #   or was aborted.
       mode(:client) do |_opts|
         update_configuration
-        fetch_keys(config.keys_url, private_key_path, public_key_path)
+        fetch_keys(config.keys_url, private_key_path, public_key_path) ? :finish : :abort
       end
 
       # List of packages to install

--- a/src/lib/y2configuration_management/configurators/puppet.rb
+++ b/src/lib/y2configuration_management/configurators/puppet.rb
@@ -27,12 +27,12 @@ module Y2ConfigurationManagement
       PRIVATE_KEY_BASE_PATH = "/var/lib/puppet/ssl/private_keys".freeze
       PUBLIC_KEY_BASE_PATH = "/var/lib/puppet/ssl/public_keys".freeze
 
-      mode(:masterless) do
+      mode(:masterless) do |_opts|
         update_configuration
         fetch_config(config.modules_url, config.work_dir)
       end
 
-      mode(:client) do
+      mode(:client) do |_opts|
         update_configuration
         fetch_keys(config.keys_url, private_key_path, public_key_path)
       end

--- a/src/lib/y2configuration_management/configurators/salt.rb
+++ b/src/lib/y2configuration_management/configurators/salt.rb
@@ -25,14 +25,15 @@ module Y2ConfigurationManagement
       PRIVATE_KEY_PATH = "/etc/salt/pki/minion/minion.pem".freeze
       PUBLIC_KEY_PATH = "/etc/salt/pki/minion/minion.pub".freeze
 
-      mode(:masterless) do
+      mode(:masterless) do |reverse: false|
         fetch_config(config.states_url, config.work_dir) if config.states_url
         fetch_config(config.pillar_url, config.pillar_root) if config.pillar_url
         update_configuration
-        Y2ConfigurationManagement::Salt::FormulaSequence.new(config).run == :finish
+        sequence = Y2ConfigurationManagement::Salt::FormulaSequence.new(config, reverse: reverse)
+        sequence.run == :finish
       end
 
-      mode(:client) do
+      mode(:client) do |_opts|
         fetch_keys(config.keys_url, private_key_path, public_key_path)
         update_configuration
       end

--- a/src/lib/y2configuration_management/configurators/salt.rb
+++ b/src/lib/y2configuration_management/configurators/salt.rb
@@ -25,17 +25,18 @@ module Y2ConfigurationManagement
       PRIVATE_KEY_PATH = "/etc/salt/pki/minion/minion.pem".freeze
       PUBLIC_KEY_PATH = "/etc/salt/pki/minion/minion.pub".freeze
 
+      # @see Base#prepare
       mode(:masterless) do |reverse: false|
         fetch_config(config.states_url, config.work_dir) if config.states_url
         fetch_config(config.pillar_url, config.pillar_root) if config.pillar_url
         update_configuration
-        sequence = Y2ConfigurationManagement::Salt::FormulaSequence.new(config, reverse: reverse)
-        sequence.run == :finish
+        Y2ConfigurationManagement::Salt::FormulaSequence.new(config, reverse: reverse).run
       end
 
+      # @see Base#prepare
       mode(:client) do |_opts|
         fetch_keys(config.keys_url, private_key_path, public_key_path)
-        update_configuration
+        update_configuration ? :finish : :abort
       end
 
       # List of packages to install

--- a/src/lib/y2configuration_management/salt/formula_configuration.rb
+++ b/src/lib/y2configuration_management/salt/formula_configuration.rb
@@ -33,9 +33,10 @@ module Y2ConfigurationManagement
       #
       # @macro seeSequence
       # @param formulas [Array<Formula>]
-      def initialize(formulas)
+      def initialize(formulas, reverse: false)
         textdomain "configuration_management"
         @formulas = formulas.select(&:enabled?)
+        @reverse = reverse
       end
 
       # @macro seeSequence
@@ -45,6 +46,8 @@ module Y2ConfigurationManagement
       end
 
     private
+
+      attr_reader :reverse
 
       # @param current_index [Integer]
       def next_formula(current_index)
@@ -65,11 +68,12 @@ module Y2ConfigurationManagement
 
       # @return [Hash]
       def sequence_hash
-        sequence = { START => formulas[0].id }
+        starting_formula = reverse ? formulas.last : formulas.first
+        sequence = { START => starting_formula.id }
         formulas.each_with_index do |formula, idx|
           sequence[formula.id] = {
             next:   next_formula(idx),
-            back:   previous_formula(idx),
+            prev:   previous_formula(idx),
             cancel: :cancel
           }
         end
@@ -82,7 +86,8 @@ module Y2ConfigurationManagement
       # @param formula [Formula]
       def configure_formula(formula)
         controller = FormController.new(formula)
-        controller.show_main_dialog
+        ret = controller.show_main_dialog
+        ret == :back ? :prev : ret
       end
     end
   end

--- a/src/lib/y2configuration_management/salt/formula_sequence.rb
+++ b/src/lib/y2configuration_management/salt/formula_sequence.rb
@@ -45,10 +45,11 @@ module Y2ConfigurationManagement
       # Constructor
       #
       # @macro seeSequence
-      # @param config [Y2ConfigurationManagement::Configurations::Salt]
-      def initialize(config)
+      # @param config [Yast::ConfigurationManagement::Configurations::Salt]
+      def initialize(config, reverse: false)
         textdomain "configuration_management"
         @config = config
+        @reverse = reverse
         read_formulas
       end
 
@@ -75,7 +76,7 @@ module Y2ConfigurationManagement
       # Iterates over the enabled {Formula}s running the {FormController} for
       # each of them.
       def configure_formulas
-        Y2ConfigurationManagement::Salt::FormulaConfiguration.new(formulas).run
+        Y2ConfigurationManagement::Salt::FormulaConfiguration.new(formulas, reverse: reverse).run
       end
 
       # Write the data associated to the selected {Formula}s into the current system
@@ -99,10 +100,12 @@ module Y2ConfigurationManagement
 
     private
 
+      attr_reader :reverse
+
       # @macro seeSequence
       def sequence_hash
         {
-          START                => "choose_formulas",
+          START                => reverse ? "configure_formulas" : "choose_formulas",
           "choose_formulas"    => {
             abort: :abort,
             next:  "configure_formulas"

--- a/src/lib/y2configuration_management/salt/formula_sequence.rb
+++ b/src/lib/y2configuration_management/salt/formula_sequence.rb
@@ -108,7 +108,8 @@ module Y2ConfigurationManagement
           START                => reverse ? "configure_formulas" : "choose_formulas",
           "choose_formulas"    => {
             abort: :abort,
-            next:  "configure_formulas"
+            next:  "configure_formulas",
+            back:  :back
           },
           "configure_formulas" => {
             cancel: "choose_formulas",

--- a/test/y2configuration_management/clients/main_test.rb
+++ b/test/y2configuration_management/clients/main_test.rb
@@ -27,7 +27,7 @@ describe Y2ConfigurationManagement::Clients::Main do
   subject(:main) { described_class.new }
 
   describe "#run" do
-    let(:prepared) { true }
+    let(:prepared) { :finish }
     let(:config) do
       { "configuration_management" =>  { "type" => "salt" } }
     end
@@ -106,7 +106,7 @@ describe Y2ConfigurationManagement::Clients::Main do
     end
 
     context "when the formulas configuration is not prepared correctly" do
-      let(:prepared) { false }
+      let(:prepared) { :abort }
 
       it "does not run the provisioner" do
         expect(provision).not_to receive(:run)

--- a/test/y2configuration_management/configurators/base_test.rb
+++ b/test/y2configuration_management/configurators/base_test.rb
@@ -46,11 +46,11 @@ describe Y2ConfigurationManagement::Configurators::Base do
     before do
       allow(config).to receive(:work_dir).and_return(work_dir)
       allow(FileUtils).to receive(:mkdir_p)
-      allow(configurator).to receive(:send).with("prepare_client")
+      allow(configurator).to receive(:send).with("prepare_client", {})
     end
 
-    it "calls to 'prepare_MODE' method" do
-      expect(configurator).to receive(:send).with("prepare_client")
+    it "calls to 'prepare_MODE' method with passed options" do
+      expect(configurator).to receive(:send).with("prepare_client", {})
       configurator.prepare
     end
 
@@ -58,7 +58,7 @@ describe Y2ConfigurationManagement::Configurators::Base do
       let(:master) { nil }
 
       before do
-        allow(configurator).to receive(:send).with("prepare_masterless")
+        allow(configurator).to receive(:send).with("prepare_masterless", {})
       end
 
       it "creates the work_dir" do

--- a/test/y2configuration_management/configurators/salt_test.rb
+++ b/test/y2configuration_management/configurators/salt_test.rb
@@ -98,7 +98,7 @@ describe Y2ConfigurationManagement::Configurators::Salt do
 
       it "runs the configuration_management_formula client" do
         expect(Y2ConfigurationManagement::Salt::FormulaSequence).to receive(:new)
-          .with(config).and_return(formula_sequence)
+          .with(config, reverse: false).and_return(formula_sequence)
         configurator.prepare
       end
 

--- a/test/y2configuration_management/salt/formula_configuration_test.rb
+++ b/test/y2configuration_management/salt/formula_configuration_test.rb
@@ -32,8 +32,9 @@ describe Y2ConfigurationManagement::Salt::FormulaConfiguration do
   let(:controller) do
     instance_double("Y2ConfigurationManagement::Salt::FormController", show_main_dialog: :cancel)
   end
+  let(:reverse) { false }
 
-  subject(:sequence) { described_class.new(formulas) }
+  subject(:sequence) { described_class.new(formulas, reverse: reverse) }
 
   describe "#run" do
     context "when there are no formulas to be configured" do
@@ -82,6 +83,25 @@ describe Y2ConfigurationManagement::Salt::FormulaConfiguration do
         it "returns :next" do
           expect(sequence.run).to eql(:next)
         end
+      end
+    end
+
+    context "when running in reverse order" do
+      let(:reverse) { true }
+
+      before do
+        formulas.each { |f| f.enabled = true }
+        allow(controller).to receive(:show_main_dialog).and_return(:back)
+      end
+
+      it "processes formulas in reverse order" do
+        formulas.reverse.each do |formula|
+          expect(Y2ConfigurationManagement::Salt::FormController)
+            .to receive(:new).with(formula.form, formula.pillar).ordered
+            .and_return(controller)
+        end
+
+        sequence.run
       end
     end
   end

--- a/test/y2configuration_management/salt/formula_configuration_test.rb
+++ b/test/y2configuration_management/salt/formula_configuration_test.rb
@@ -97,7 +97,7 @@ describe Y2ConfigurationManagement::Salt::FormulaConfiguration do
       it "processes formulas in reverse order" do
         formulas.reverse.each do |formula|
           expect(Y2ConfigurationManagement::Salt::FormController)
-            .to receive(:new).with(formula.form, formula.pillar).ordered
+            .to receive(:new).with(formula).ordered
             .and_return(controller)
         end
 


### PR DESCRIPTION
Required by https://github.com/yast/yast-firstboot/pull/61.

* Allow to run the `FormulaSequence` in reverse order.
* Allow to pass additional arguments to the configurators.