### PR TITLE
Added "BuildRequires: update-desktop-files"

### DIFF
--- a/package/yast2-configuration-management.changes
+++ b/package/yast2-configuration-management.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 19 09:24:05 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added "BuildRequires: update-desktop-files"
+- Related to the previous desktop file changes (fate#319035)
+- 4.2.1
+
+-------------------------------------------------------------------
 Fri May 31 12:27:52 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Add metainfo (fate#319035)

--- a/package/yast2-configuration-management.spec
+++ b/package/yast2-configuration-management.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-configuration-management
-Version:        4.2.0
+Version:        4.2.1
 Release:        0
 Url:            https://github.com/yast/yast-migration
 Summary:        YaST2 - YaST Configuration Management
@@ -32,6 +32,7 @@ BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  yast2-installation
 BuildRequires:  rubygem(rspec)
 BuildRequires:  rubygem(yast-rake)
+BuildRequires:  update-desktop-files
 
 # CWM DateField and TimeField widgets
 Requires:       yast2 => 4.1.53


### PR DESCRIPTION
- The recent fix in YaST RPM macros now updates the desktop files
- The `%suse_update_desktop_file` macro is defined in the `update-desktop-files` package
- Without it the macro is not expanded and the shell treats `%` as a job control character and fails with error `fg: no job control`