### PR TITLE
Remove menu entry from the AutoYaST UI

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,4 @@ Yast::Tasks.submit_to :sle15sp1
 Yast::Tasks.configuration do |conf|
   # lets ignore license check for now
   conf.skip_license_check << /.*/
-
-  conf.install_locations["startup"] = Packaging::Configuration::YAST_LIB_DIR
 end

--- a/package/yast2-configuration-management.changes
+++ b/package/yast2-configuration-management.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Dec 17 14:12:07 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Remove the AutoYaST User Interface menu entry for the module
+  because, for the time being, it is not supported (bsc#1159434).
+- 4.1.7
+
+-------------------------------------------------------------------
 Thu Feb 28 19:22:52 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix $visibleIf condition evaluation when the left value is "false"

--- a/package/yast2-configuration-management.spec
+++ b/package/yast2-configuration-management.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-configuration-management
-Version:        4.1.6
+Version:        4.1.7
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/desktop/configuration_management.desktop
+++ b/src/desktop/configuration_management.desktop
@@ -4,7 +4,7 @@ Categories=Settings;System;Qt;X-SuSE-YaST;X-SuSE-YaST-Misc;
 X-SuSE-YaST-Call=configuration_management
 
 X-SuSE-YaST-Group=Misc
-X-SuSE-YaST-AutoInst=all
+X-SuSE-YaST-AutoInst=write
 X-SuSE-YaST-AutoInstClonable=false
 X-SuSE-YaST-AutoInstRequires=lan
 X-SuSE-YaST-AutoInstSchema=configuration_management.rnc


### PR DESCRIPTION
The module does not have support for the AutoYaST UI, so it should not have a menu entry. See the [AutoYaST specific keys section](https://github.com/yast/yast-yast2/blob/6bc7bd9f1ef03f783ed269cd59174fe9e8a25c78/doc/desktop_file.md#autoyast-specific-keys) for more information about the meaning of the `X-SuSE-YaST-AutoInst` key.

It fixes [bsc#1159324](https://bugzilla.suse.com/show_bug.cgi?id=1159324).