### PR TITLE
[bsc#1168080] Allow no formulas

### DIFF
--- a/package/yast2-configuration-management.changes
+++ b/package/yast2-configuration-management.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar 30 21:01:50 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not force to use formulas during the 1st stage (bsc#1168080).
+- 4.2.4
+
+-------------------------------------------------------------------
 Tue Dec 17 14:12:07 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Remove the AutoYaST User Interface menu entry for the module

--- a/package/yast2-configuration-management.spec
+++ b/package/yast2-configuration-management.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-configuration-management
-Version:        4.2.3
+Version:        4.2.4
 Release:        0
 Url:            https://github.com/yast/yast-migration
 Summary:        YaST2 - YaST Configuration Management

--- a/src/lib/y2configuration_management/clients/configuration_management_finish.rb
+++ b/src/lib/y2configuration_management/clients/configuration_management_finish.rb
@@ -24,8 +24,8 @@ module Y2ConfigurationManagement
     #                                otherwise it returns false.
     def write
       return false if config.nil?
-      log.info("Provisioning Configuration Management")
-      configurator.prepare
+      log.info("Provisioning Configuration Management with config #{config.inspect}")
+      configurator.prepare(require_formulas: false)
       # saving settings to target system
       Y2ConfigurationManagement::Clients::Provision.new.run
 

--- a/src/lib/y2configuration_management/clients/main.rb
+++ b/src/lib/y2configuration_management/clients/main.rb
@@ -62,7 +62,7 @@ module Y2ConfigurationManagement
         log.info("Provisioning Configuration Management")
         config = Y2ConfigurationManagement::Configurations::Base.import(settings)
         configurator = Y2ConfigurationManagement::Configurators::Base.for(config)
-        ret = configurator.prepare
+        ret = configurator.prepare(require_formulas: true)
         return ret unless ret == :finish
         if !Yast::PackageSystem.CheckAndInstallPackages(configurator.packages.fetch("install", []))
           return :abort

--- a/src/lib/y2configuration_management/configurators/salt.rb
+++ b/src/lib/y2configuration_management/configurators/salt.rb
@@ -26,11 +26,14 @@ module Y2ConfigurationManagement
       PUBLIC_KEY_PATH = "/etc/salt/pki/minion/minion.pub".freeze
 
       # @see Base#prepare
-      mode(:masterless) do |reverse: false|
+      mode(:masterless) do |reverse: false, require_formulas: false|
         fetch_config(config.states_url, config.work_dir) if config.states_url
         fetch_config(config.pillar_url, config.pillar_root) if config.pillar_url
         update_configuration
-        Y2ConfigurationManagement::Salt::FormulaSequence.new(config, reverse: reverse).run
+        sequence = Y2ConfigurationManagement::Salt::FormulaSequence.new(
+          config, reverse: reverse, require_formulas: require_formulas
+        )
+        sequence.run
       end
 
       # @see Base#prepare

--- a/test/y2configuration_management/clients/finish_client_test.rb
+++ b/test/y2configuration_management/clients/finish_client_test.rb
@@ -35,7 +35,7 @@ describe Y2ConfigurationManagement::ConfigurationManagementFinish do
       let(:config) { double("config", enable_services: false) }
 
       it "runs the configurator" do
-        expect(configurator).to receive(:prepare)
+        expect(configurator).to receive(:prepare).with(require_formulas: false)
         client.write
       end
 

--- a/test/y2configuration_management/clients/main_test.rb
+++ b/test/y2configuration_management/clients/main_test.rb
@@ -88,6 +88,11 @@ describe Y2ConfigurationManagement::Clients::Main do
       end
     end
 
+    it "configures the provisioner" do
+      expect(configurator).to receive(:prepare).with(require_formulas: true)
+      main.run
+    end
+
     it "ensures that needed packages are installed" do
       expect(Yast::PackageSystem).to receive(:CheckAndInstallPackages).with(["salt"])
         .and_return(true)

--- a/test/y2configuration_management/configurators/salt_test.rb
+++ b/test/y2configuration_management/configurators/salt_test.rb
@@ -96,9 +96,9 @@ describe Y2ConfigurationManagement::Configurators::Salt do
         configurator.prepare
       end
 
-      it "runs the configuration_management_formula client" do
+      it "runs the formulas sequence" do
         expect(Y2ConfigurationManagement::Salt::FormulaSequence).to receive(:new)
-          .with(config, reverse: false).and_return(formula_sequence)
+          .with(config, reverse: false, require_formulas: false).and_return(formula_sequence)
         configurator.prepare
       end
 

--- a/test/y2configuration_management/salt/formula_sequence_test.rb
+++ b/test/y2configuration_management/salt/formula_sequence_test.rb
@@ -41,7 +41,7 @@ describe Y2ConfigurationManagement::Salt::FormulaSequence do
   end
   let(:tmpdir) { Pathname(Dir.mktmpdir) }
   let(:reverse) { false }
-  subject(:sequence) { described_class.new(config, reverse: reverse) }
+  subject(:sequence) { described_class.new(config, reverse: reverse, require_formulas: true) }
 
   before do
     allow(config).to receive(:work_dir).and_return(tmpdir)
@@ -130,12 +130,24 @@ describe Y2ConfigurationManagement::Salt::FormulaSequence do
 
       it "reports an error" do
         expect(Yast::Report).to receive(:Error).with(/There are no formulas available/)
-
         sequence.choose_formulas
       end
 
       it "returns :abort" do
         expect(sequence.choose_formulas).to eql(:abort)
+      end
+
+      context "but formulas are not required" do
+        subject(:sequence) { described_class.new(config, require_formulas: false) }
+
+        it "does not report any error" do
+          expect(Yast::Report).to_not receive(:Error)
+          sequence.choose_formulas
+        end
+
+        it "returns :finish" do
+          expect(sequence.choose_formulas).to eql(:finish)
+        end
       end
     end
   end


### PR DESCRIPTION
When running in the 1st stage, yast2-configuration-management complains if there are no formulas. However, it is expected to no have formulas during the 1st stage.

[bsc#1168080](https://bugzilla.suse.com/show_bug.cgi?id=1168080).