### PR TITLE
Support for mulitple pillars

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,16 @@ the required workflow. In the example below, only the relevant parts are shown:
         <pillar_root>/srv/susemanager/formula_data</pillar_root>
       </listentry>
       <listentry>
+        <metadata_root>/usr/share/salt-formulas/metadata</metadata_root>
+        <states_root>/usr/share/salt-formulas/states</states_root>
+        <pillar_root>/srv/salt-formulas/pillar</pillar_root>
+      </listentry>
+      <listentry>
         <metadata_root>/srv/formula_metadata</metadata_root>
       </listentry>
     </formulas_sets>
     <!-- Default Salt Formulas pillar data directory  -->
-    <pillar_root>/srv/susemanager/formula_data</pillar_root>
+    <pillar_root>/srv/pillar</pillar_root>
   </configuration_management>
 
   <!-- more stuff -->

--- a/README.md
+++ b/README.md
@@ -85,15 +85,17 @@ the required workflow. In the example below, only the relevant parts are shown:
 
   <configuration_management>
     <type>salt</type>
-    <!-- Default Salt Formulas root directories -->
-    <formulas_roots config:type="list">
-      <formulas_root>/usr/share/susemanager/formulas/metadata</formulas_root>
-      <formulas_root>/srv/formula_metadata</formulas_root>
-    </formulas_roots>
-    <!-- Default Salt Formulas state directories -->
-    <states_roots config:type="list">
-      <states_root>/usr/share/susemanager/formulas/states</states_root>
-    </states_roots>
+    <!-- Default Salt Formulas directories -->
+    <formulas_sets config:type="list">
+      <listentry>
+        <metadata_root>/usr/share/susemanager/formulas/metadata</metadata_root>
+        <states_root>/usr/share/susemanager/formulas/states</states_root>
+        <pillar_root>/srv/susemanager/formula_data</pillar_root>
+      </listentry>
+      <listentry>
+        <metadata_root>/srv/formula_metadata</metadata_root>
+      </listentry>
+    </formulas_sets>
     <!-- Default Salt Formulas pillar data directory  -->
     <pillar_root>/srv/susemanager/formula_data</pillar_root>
   </configuration_management>

--- a/README.md
+++ b/README.md
@@ -84,18 +84,18 @@ the required workflow. In the example below, only the relevant parts are shown:
   xmlns:config="http://www.suse.com/1.0/configns">
 
   <configuration_management>
-      <type>salt</type>
-      <!-- Default Salt Formulas root directories -->
-      <formulas_roots config:type="list">
-        <formulas_root>/usr/share/susemanager/formulas/metadata</formulas_root>
-        <formulas_root>/srv/formula_metadata</formulas_root>
-      </formulas_roots>
-      <!-- Default Salt Formulas state directories -->
-      <states_roots config:type="list">
-        <states_root>/usr/share/susemanager/formulas/states</states_root>
-      </states_roots>
-      <!-- Default Salt Formulas pillar data directory  -->
-      <pillar_root>/srv/susemanager/formula_data</pillar_root>
+    <type>salt</type>
+    <!-- Default Salt Formulas root directories -->
+    <formulas_roots config:type="list">
+      <formulas_root>/usr/share/susemanager/formulas/metadata</formulas_root>
+      <formulas_root>/srv/formula_metadata</formulas_root>
+    </formulas_roots>
+    <!-- Default Salt Formulas state directories -->
+    <states_roots config:type="list">
+      <states_root>/usr/share/susemanager/formulas/states</states_root>
+    </states_roots>
+    <!-- Default Salt Formulas pillar data directory  -->
+    <pillar_root>/srv/susemanager/formula_data</pillar_root>
   </configuration_management>
 
   <!-- more stuff -->
@@ -120,16 +120,13 @@ the required workflow. In the example below, only the relevant parts are shown:
 
 ## Salt Formulas Forms Support
 
-**WARNING: Under development.**
+[Salt Formulas
+Forms](https://documentation.suse.com/external-tree/en-us/suma/3.2/susemanager-best-practices/single-html/book.suma.best.practices/book.suma.best.practices.html#best.practice.salt.formulas.and.forms)
+are supported. If you find out that some feature is not missing, please, open a
+[bug report](https://bugzilla.opensuse.org/).
 
-The support for Salt Formulas Forms is still under development. Currently, the module is able to
-render the corresponding UI to get user's input, store the information and run Salt accordingly.
-However, some stuff is still missing:
-
-* Some basic widgets are not implemented yet (passwords, numbers, etc.).
-* Support for nested collections, although simple collections are already working.
-* Better integration with Firstboot (supporting stuff like going back or running Salt at the end).
-* Good documentation.
+The supported types are: `text`, `password`, `number`, `url`, `email`, `date`, `time`, `datetime`,
+`boolean`, `color`, `select`, `group`, `edit-group`, and `namespace`.
 
 ## Options Reference
 

--- a/README.md
+++ b/README.md
@@ -132,8 +132,9 @@ Forms](https://documentation.suse.com/external-tree/en-us/suma/3.2/susemanager-b
 are supported. If you find out that some feature is missing, please, open a
 [bug report](https://bugzilla.opensuse.org/).
 
-The supported types are: `text`, `password`, `number`, `url`, `email`, `date`, `time`, `datetime`,
-`boolean`, `color`, `select`, `group`, `edit-group`, and `namespace`.
+The supported widget types are listed in the
+{Y2ConfigurationManagement::Salt::FormBuilder::INPUT_WIDGET_CLASS} constant. Additionally, groups
+(`group` and `namespace`) and collections (`edit-group`) are supported too.
 
 ## Options Reference
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ the required workflow. In the example below, only the relevant parts are shown:
 
 [Salt Formulas
 Forms](https://documentation.suse.com/external-tree/en-us/suma/3.2/susemanager-best-practices/single-html/book.suma.best.practices/book.suma.best.practices.html#best.practice.salt.formulas.and.forms)
-are supported. If you find out that some feature is not missing, please, open a
+are supported. If you find out that some feature is missing, please, open a
 [bug report](https://bugzilla.opensuse.org/).
 
 The supported types are: `text`, `password`, `number`, `url`, `email`, `date`, `time`, `datetime`,

--- a/src/lib/y2configuration_management/cfa/minion.rb
+++ b/src/lib/y2configuration_management/cfa/minion.rb
@@ -35,15 +35,33 @@ module Y2ConfigurationManagement
       end
 
       # Set file roots for a given environment
+      #
+      # @param roots [Array<String>] Names of the directories to be used as `file_roots`
+      # @param env [String] Environment name (e.g., "base")
       def set_file_roots(roots, env = "base")
-        self.data ||= {}
-        data["file_roots"] ||= {}
-        data["file_roots"][env] = roots.map(&:to_s)
+        set_array(:file_roots, roots, env)
+      end
+
+      # Set pillar roots for a given environment
+      #
+      # @param roots [Array<String>] Names of the directories to be used as `pillar_roots`
+      # @param env [String] Environment name (e.g., "base")
+      def set_pillar_roots(roots, env = "base")
+        set_array(:pillar_roots, roots, env)
       end
 
       # Get file roots for a given environment
+      #
+      # @param env [String] Environment name (e.g., "base")
       def file_roots(env)
         data.fetch("file_roots", {}).fetch(env, [])
+      end
+
+      # Get pillar roots for a given environment
+      #
+      # @param env [String] Environment name (e.g., "base")
+      def pillar_roots(env)
+        data.fetch("pillar_roots", {}).fetch(env, [])
       end
 
       # Save the configuration file
@@ -70,6 +88,18 @@ module Y2ConfigurationManagement
         dirname = File.dirname(@file_path)
         return if Yast::FileUtils.Exists(dirname)
         Yast::SCR.Execute(Yast::Path.new(".target.mkdir"), dirname)
+      end
+
+      # Sets an array-like value for a given key
+      #
+      # @param key [String,Symbol] Key name
+      # @param items [Array<#to_s>] List of elements to include
+      # @param env [String] Environment name (e.g., "base")
+      def set_array(key, items, env = "base")
+        self.data ||= {}
+        key = key.to_s
+        data[key] ||= {}
+        data[key][env] = items.map(&:to_s)
       end
     end
   end

--- a/src/lib/y2configuration_management/clients/auto_client.rb
+++ b/src/lib/y2configuration_management/clients/auto_client.rb
@@ -9,17 +9,30 @@ Yast.import "PackagesProposal"
 module Y2ConfigurationManagement
   # AutoClient implementation
   #
-  # The real work is delegated to Configurators.
+  # This module takes care of importing and configuring the configuration management module so the
+  # {ConfigurationManagementFinish} can provision the system at the end of the installation.
   #
-  # @see Y2ConfigurationManagement::Configurators
+  # It takes care of:
+  #
+  # * Importing the configuration (see {Configurations::Base.import}).
+  # * Initializing the configurator (see {Configurators::Base.for}).
+  # * Adding the required packages to the list of packages to install.
+  #
+  # It might change in the future but at this point in time this client only uses the information
+  # specified in the AutoYaST profile. For instance, when using Salt, it does not consider the
+  # formulas installed via RPM packages in the target system.
+  #
+  # @see Configurations
+  # @see Configurators
   class AutoClient < ::Installation::AutoClient
     include Yast::I18n
 
     # Import AutoYaST configuration
     #
-    # Additional configurator-specific options can be specified. They will be passed
-    # to the configurator's constructor.
+    # Additional configurator-specific options can be specified. They will be passed to the
+    # configurator's constructor.
     #
+    # @param profile [Hash] Options from an AutoYaST profile
     # @option profile [String] "type"            Configurator to use ("salt", "puppet", etc.)
     # @option profile [String] "master"          Master server name
     # @option profile [String] "auth_attempts"   Number of authentication attempts
@@ -49,8 +62,8 @@ module Y2ConfigurationManagement
 
     # Determines whether the profile data has been modified
     #
-    # This method always returns `false` because no information from this
-    # module is included in the cloned profile.
+    # This method always returns `false` because no information from this module is included in the
+    # cloned profile.
     #
     # @return [true]
     def modified?
@@ -59,8 +72,8 @@ module Y2ConfigurationManagement
 
     # Sets the profile as modified
     #
-    # This method does not perform any modification because no information
-    # from this module is included in the cloned profile.
+    # This method does not perform any modification because no information from this module is
+    # included in the cloned profile.
     #
     # @return [true]
     def modified

--- a/src/lib/y2configuration_management/clients/auto_client.rb
+++ b/src/lib/y2configuration_management/clients/auto_client.rb
@@ -18,9 +18,9 @@ module Y2ConfigurationManagement
   # * Initializing the configurator (see {Configurators::Base.for}).
   # * Adding the required packages to the list of packages to install.
   #
-  # It might change in the future but at this point in time this client only uses the information
-  # specified in the AutoYaST profile. For instance, when using Salt, it does not consider the
-  # formulas installed via RPM packages in the target system.
+  # This client is used during the 1st stage only. At this point in time, it just uses the
+  # information specified in the profile, i.e., it does not uses formulas from the target system
+  # (usually installed via RPM packages).
   #
   # @see Configurations
   # @see Configurators

--- a/src/lib/y2configuration_management/clients/configuration_management_finish.rb
+++ b/src/lib/y2configuration_management/clients/configuration_management_finish.rb
@@ -9,7 +9,12 @@ Yast.import "Service"
 module Y2ConfigurationManagement
   # Client to write the provisioner's configuration
   #
-  # @see Y2ConfigurationManagement::Configurators
+  # This client requires that the configurator and the configurators are already
+  # available (see {AutoClient}).
+  #
+  # @see Configurators
+  # @see Configurations
+  # @see Provision
   class ConfigurationManagementFinish < ::Installation::FinishClient
     include Yast::I18n
 

--- a/src/lib/y2configuration_management/clients/main.rb
+++ b/src/lib/y2configuration_management/clients/main.rb
@@ -30,7 +30,8 @@ module Y2ConfigurationManagement
   module Clients
     # Basic client to run the configuration management tools
     #
-    # It reads the configuration from an XML file.
+    # It reads the configuration from an XML file if present (and given as first argument).
+    # Otherwise, it uses the default values (based on Salt).
     #
     # @example Configuration example
     #   <configuration_management>

--- a/src/lib/y2configuration_management/clients/main.rb
+++ b/src/lib/y2configuration_management/clients/main.rb
@@ -36,30 +36,45 @@ module Y2ConfigurationManagement
     # @example Configuration example
     #   <configuration_management>
     #     <type>salt</type>
-    #     <states_roots config:type="list">
-    #       <listitem>/srv/salt</listitem>
-    #     </states_roots>
-    #     <formulas_roots config:type="list">
-    #       <listitem>/srv/formulas</listitem>
-    #     </formulas_roots>
-    #     <pillar_root>/srv/pillar</pillar_root>
+    #     <formulas_sets config:type="list">
+    #       <listentry>
+    #         <metadata_root>/usr/share/susemanager/formulas/metadata</metadata_root>
+    #         <states_root>/usr/share/susemanager/formulas/states</states_root>
+    #         <pillar_root>/srv/susemanager/formula_data</pillar_root>
+    #       </listentry>
+    #       <listentry>
+    #         <metadata_root>/srv/formula_metadata</metadata_root>
+    #       </listentry>
+    #     </formulas_sets>
     #   </configuration_management>
     class Main < Yast::Client
       include Yast::Logger
 
       # @see https://documentation.suse.com/external-tree/en-us/suma/3.2/susemanager-best-practices/single-html/book.suma.best.practices/book.suma.best.practices.html#best.practice.salt.formulas.what
-      FORMULAS_BASE = "/usr/share/susemanager/formulas".freeze
+      SUMA_FORMULAS_BASE = "/usr/share/susemanager/formulas".freeze
+      FORMULAS_BASE = "/usr/share/salt-formulas".freeze
 
       # FIXME: define default values in the {Y2ConfigurationManagement::Configurations} module.
       DEFAULT_SETTINGS = {
-        "type"           => "salt",
-        "formulas_roots" => [
-          File.join(FORMULAS_BASE, "metadata"), "/srv/formula_metadata"
+        "type"          => "salt",
+        "formulas_sets" => [
+          {
+            "metadata_root" => File.join(SUMA_FORMULAS_BASE, "metadata"),
+            "states_root"   => File.join(SUMA_FORMULAS_BASE, "states"),
+            "pillar_root"   => "/srv/susemanager/formula_data/pillar"
+          },
+          {
+            "metadata_root" => File.join(FORMULAS_BASE, "metadata"),
+            "states_root"   => File.join(FORMULAS_BASE, "states"),
+            "pillar_root"   => "/srv/salt-formulas/pillar"
+          },
+          {
+            "metadata_root" => "/srv/formula_metadata"
+          }
         ],
-        "states_roots"   => [
-          File.join(FORMULAS_BASE, "states"), "/srv/salt"
-        ],
-        "pillar_root"    => "/srv/susemanager/formula_data"
+        "states_roots"  => [
+          "/srv/salt"
+        ]
       }.freeze
 
       # Runs the client

--- a/src/lib/y2configuration_management/clients/main.rb
+++ b/src/lib/y2configuration_management/clients/main.rb
@@ -47,14 +47,19 @@ module Y2ConfigurationManagement
     class Main < Yast::Client
       include Yast::Logger
 
+      # @see https://documentation.suse.com/external-tree/en-us/suma/3.2/susemanager-best-practices/single-html/book.suma.best.practices/book.suma.best.practices.html#best.practice.salt.formulas.what
+      FORMULAS_BASE = "/usr/share/susemanager/formulas".freeze
+
+      # FIXME: define default values in the {Y2ConfigurationManagement::Configurations} module.
       DEFAULT_SETTINGS = {
         "type"           => "salt",
-        "formulas_roots" => Y2ConfigurationManagement::Salt::Formula.formula_directories,
-        "states_roots"   => [
-          Y2ConfigurationManagement::Salt::Formula::BASE_DIR + "/states",
-          "/srv/salt/"
+        "formulas_roots" => [
+          File.join(FORMULAS_BASE, "metadata"), "/srv/formula_metadata"
         ],
-        "pillar_root"    => Y2ConfigurationManagement::Salt::Formula::DATA_DIR + "/pillar"
+        "states_roots"   => [
+          File.join(FORMULAS_BASE, "states"), "/srv/salt"
+        ],
+        "pillar_root"    => "/srv/susemanager/formula_data"
       }.freeze
 
       # Runs the client

--- a/src/lib/y2configuration_management/clients/provision.rb
+++ b/src/lib/y2configuration_management/clients/provision.rb
@@ -5,12 +5,13 @@ require "y2configuration_management/configurations/base"
 
 module Y2ConfigurationManagement
   module Clients
-    # TODO: move this code to the finish client
-
-    # This client takes care of running the provisioning in order to configure the system.
-    # The real work is implemented by runners.
+    # This client takes care of provisioning the system, although the real work
+    # is implemented by its correspondant {Runners}.
+    #
+    # It is used by {ConfigurationManagementFinish}, {Main} and firstboot clients.
     #
     # @see Y2ConfigurationManagement::Runners
+    # TODO: use a regular class instead of a client.
     class Provision < Yast::Client
       # Run the client
       def run

--- a/src/lib/y2configuration_management/configurations/base.rb
+++ b/src/lib/y2configuration_management/configurations/base.rb
@@ -46,13 +46,21 @@ module Y2ConfigurationManagement
 
         # Import settings from an AutoYaST profile
         #
-        # @param profile [Hash] Configuration management settings from profile
-        def import(profile)
-          self.current = self.for(profile)
+        # It saves the configuration that can be retrieved later by calling to the
+        # {.current} method.
+        #
+        # @param options [Hash<String,Object>] Settings from a profile or a control file
+        def import(options)
+          self.current = from_hash(options)
         end
 
-        def for(config)
-          class_for(config["type"]).new(config)
+        # Returns the settings for the given hash configuration
+        #
+        # @param options [Hash] Configuration management settings
+        # @return [Base] Returns the configuration. It uses the `:type` key to determine its type.
+        def from_hash(options)
+          symbolized_opts = Hash[options.map { |k, v| [k.to_sym, v] }]
+          class_for(symbolized_opts[:type]).new(symbolized_opts)
         end
 
         def class_for(type)
@@ -63,15 +71,24 @@ module Y2ConfigurationManagement
         end
       end
 
-      def initialize(options)
-        symbolized_opts = Hash[options.map { |k, v| [k.to_sym, v] }]
-        @master           = symbolized_opts[:master]
-        @mode             = @master ? :client : :masterless
-        @keys_url         = URI(symbolized_opts[:keys_url]) if symbolized_opts[:keys_url]
-        @auth_attempts    = symbolized_opts[:auth_attempts] || DEFAULT_AUTH_ATTEMPTS
-        @auth_time_out    = symbolized_opts[:auth_time_out] || DEFAULT_AUTH_TIME_OUT
-        @enable_services  = symbolized_opts[:enable_services] || true
-        post_initialize(symbolized_opts)
+      # Constructor
+      #
+      # Derived classes override the {#post_initialize} method to handle additional options.
+      #
+      # @param options [Hash<Symbol,Object>] Options
+      # @option options [String,nil] master Master server
+      # @option options [String] :keys_url Authentication keys URL
+      # @option options [Integer] :auth_attempts Authentication attempts
+      # @option options [Integer] :auth_time_out Authentication timeout for each attempt
+      # @option options [Boolean] :enable_services Whether to enable the provisioner service
+      def initialize(options = {})
+        @master          = options[:master]
+        @mode            = @master ? :client : :masterless
+        @keys_url        = URI(options[:keys_url]) if options[:keys_url]
+        @auth_attempts   = options[:auth_attempts] || DEFAULT_AUTH_ATTEMPTS
+        @auth_time_out   = options[:auth_time_out] || DEFAULT_AUTH_TIME_OUT
+        @enable_services = options[:enable_services] || true
+        post_initialize(options)
       end
 
       # Hook to run after initializing the instance

--- a/src/lib/y2configuration_management/configurations/base.rb
+++ b/src/lib/y2configuration_management/configurations/base.rb
@@ -49,18 +49,29 @@ module Y2ConfigurationManagement
         # It saves the configuration that can be retrieved later by calling to the
         # {.current} method.
         #
-        # @param options [Hash<String,Object>] Settings from a profile or a control file
-        def import(options)
-          self.current = from_hash(options)
+        # @param hash [Hash<String,Object>] Settings from a profile or a control file
+        def import(hash)
+          self.current = from_hash(hash)
         end
 
-        # Returns the settings for the given hash configuration
+        # Returns a configuration according to the given hash
         #
-        # @param options [Hash] Configuration management settings
+        # @param hash [Hash] Configuration management settings
         # @return [Base] Returns the configuration. It uses the `:type` key to determine its type.
-        def from_hash(options)
-          symbolized_opts = Hash[options.map { |k, v| [k.to_sym, v] }]
-          class_for(symbolized_opts[:type]).new(symbolized_opts)
+        def from_hash(hash)
+          klass = class_for(hash["type"])
+          klass.new_from_hash(hash)
+        end
+
+        # Returns a configuration according to the given hash
+        #
+        # Dervide classes may redefined this method.
+        #
+        # @param hash [Hash] Configuration management setting
+        # @return [Base] Configuration instance
+        def new_from_hash(hash)
+          options = Hash[hash.map { |k, v| [k.to_sym, v] }]
+          new(options)
         end
 
         def class_for(type)

--- a/src/lib/y2configuration_management/configurations/base.rb
+++ b/src/lib/y2configuration_management/configurations/base.rb
@@ -7,8 +7,18 @@ Yast.import "Installation"
 Yast.import "Directory"
 
 module Y2ConfigurationManagement
+  # This module provides the classes to process the configuration
+  #
+  # These classes are responsible for processing and storing the configuration
+  # to be used by the provisioners (Salt or Puppet). They keep information about
+  # the operation mode, the server hostname, the number of attempts, timeouts,
+  # etc.
+  #
+  # The common settings and behaviour are implemented in the {Base} class.
+  # {Salt} and {Puppet} classes extend it in order to provide the specific
+  # bits for each provisioner.
   module Configurations
-    # This class inteprets the module configuration
+    # This class implements the current behaviour for configuration classes
     class Base
       # Default value for auth_attempts
       DEFAULT_AUTH_ATTEMPTS = 3

--- a/src/lib/y2configuration_management/configurations/base.rb
+++ b/src/lib/y2configuration_management/configurations/base.rb
@@ -87,18 +87,20 @@ module Y2ConfigurationManagement
       # Derived classes override the {#post_initialize} method to handle additional options.
       #
       # @param options [Hash<Symbol,Object>] Options
-      # @option options [String,nil] master Master server
+      # @option options [String,nil] :master Master server
       # @option options [String] :keys_url Authentication keys URL
       # @option options [Integer] :auth_attempts Authentication attempts
       # @option options [Integer] :auth_time_out Authentication timeout for each attempt
       # @option options [Boolean] :enable_services Whether to enable the provisioner service
+      #
+      # @raise URI::InvalidURIError
       def initialize(options = {})
         @master          = options[:master]
         @mode            = @master ? :client : :masterless
         @keys_url        = URI(options[:keys_url]) if options[:keys_url]
         @auth_attempts   = options[:auth_attempts] || DEFAULT_AUTH_ATTEMPTS
         @auth_time_out   = options[:auth_time_out] || DEFAULT_AUTH_TIME_OUT
-        @enable_services = options[:enable_services] || true
+        @enable_services = !!options[:enable_services]
         post_initialize(options)
       end
 

--- a/src/lib/y2configuration_management/configurations/formulas_set.rb
+++ b/src/lib/y2configuration_management/configurations/formulas_set.rb
@@ -39,7 +39,7 @@ module Y2ConfigurationManagement
       # @param states_root [Pathname,nil] Directory where the states are located
       # @param pillar_root [Pathname,nil] Directory where the pillar data is stored
       def initialize(metadata_root, states_root = nil, pillar_root = nil)
-        @metadata_root = Pathname.new(metadata_root) if metadata_root
+        @metadata_root = Pathname.new(metadata_root)
         @states_root = Pathname.new(states_root) if states_root
         @pillar_root = Pathname.new(pillar_root) if pillar_root
       end

--- a/src/lib/y2configuration_management/configurations/formulas_set.rb
+++ b/src/lib/y2configuration_management/configurations/formulas_set.rb
@@ -1,0 +1,48 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "pathname"
+
+module Y2ConfigurationManagement
+  module Configurations
+    # Ancillary class to define the details of where a set of formulas are located
+    #
+    # It contains the path to the components of the formula: metadata, states and pillar
+    # directories.
+    class FormulasSet
+      # @return [Pathname]
+      attr_reader :metadata_root
+      # @return [Pathname,nil]
+      attr_reader :states_root
+      # @return [Pathname,nil]
+      attr_reader :pillar_root
+
+      # Constructor
+      #
+      # @param metadata_root [Pathname] Directory where formulas metadata is located
+      # @param states_root [Pathname,nil] Directory where the states are located
+      # @param pillar_root [Pathname,nil] Directory where the pillar data is stored
+      def initialize(metadata_root, states_root = nil, pillar_root = nil)
+        @metadata_root = Pathname.new(metadata_root) if metadata_root
+        @states_root = Pathname.new(states_root) if states_root
+        @pillar_root = Pathname.new(pillar_root) if pillar_root
+      end
+    end
+  end
+end

--- a/src/lib/y2configuration_management/configurations/puppet.rb
+++ b/src/lib/y2configuration_management/configurations/puppet.rb
@@ -12,7 +12,8 @@ module Y2ConfigurationManagement
 
       # Custom initialization code
       #
-      # @param options [Hash] Constructor options
+      # @param options [Hash<Symbol,Object>] Constructor options
+      # @option options [URI,String] modules_url URL to get the modules from
       def post_initialize(options)
         @type = "puppet"
         @modules_url = URI(options[:modules_url]) if options[:modules_url]

--- a/src/lib/y2configuration_management/configurations/puppet.rb
+++ b/src/lib/y2configuration_management/configurations/puppet.rb
@@ -14,6 +14,7 @@ module Y2ConfigurationManagement
       #
       # @param options [Hash<Symbol,Object>] Constructor options
       # @option options [URI,String,nil] :modules_url URL to get the modules from
+      #   Ignored when running in :client mode.
       #
       # @raise URI::InvalidURIError
       def post_initialize(options)

--- a/src/lib/y2configuration_management/configurations/puppet.rb
+++ b/src/lib/y2configuration_management/configurations/puppet.rb
@@ -2,11 +2,10 @@ require "y2configuration_management/configurations/base"
 
 module Y2ConfigurationManagement
   module Configurations
-    # This class represents the module's configuration when
-    # using Puppet.
+    # This class represents the module's configuration when using Puppet.
     #
-    # It extends the Configurations::Base class with some
-    # custom attributes (@see #modules_url).
+    # It extends the Configurations::Base class with some Puppet specific options.
+    # See #post_initialize for further information about those options.
     class Puppet < Base
       # @return [URI,nil] Location of Puppet modules
       attr_reader :modules_url
@@ -15,7 +14,7 @@ module Y2ConfigurationManagement
       #
       # @param options [Hash] Constructor options
       def post_initialize(options)
-        @type        = "puppet"
+        @type = "puppet"
         @modules_url = URI(options[:modules_url]) if options[:modules_url]
       end
     end

--- a/src/lib/y2configuration_management/configurations/puppet.rb
+++ b/src/lib/y2configuration_management/configurations/puppet.rb
@@ -13,7 +13,9 @@ module Y2ConfigurationManagement
       # Custom initialization code
       #
       # @param options [Hash<Symbol,Object>] Constructor options
-      # @option options [URI,String] modules_url URL to get the modules from
+      # @option options [URI,String,nil] :modules_url URL to get the modules from
+      #
+      # @raise URI::InvalidURIError
       def post_initialize(options)
         @type = "puppet"
         @modules_url = URI(options[:modules_url]) if options[:modules_url]

--- a/src/lib/y2configuration_management/configurations/salt.rb
+++ b/src/lib/y2configuration_management/configurations/salt.rb
@@ -17,7 +17,7 @@ module Y2ConfigurationManagement
 
       # Custom initialization code
       #
-      # @param options [Hash] Constructor options
+      # @param options [Hash<Symbol,Object>] Constructor options
       # @option options [String] :states_url URL of the states tarball
       # @option options [String] :pillar_url URL of the pillar data tarball
       # @option options [String,Pathname] :pillar_root Path to the pillar data directory

--- a/src/lib/y2configuration_management/configurations/salt.rb
+++ b/src/lib/y2configuration_management/configurations/salt.rb
@@ -3,11 +3,10 @@ require "pathname"
 
 module Y2ConfigurationManagement
   module Configurations
-    # This class represents the module's configuration when
-    # using Salt.
+    # This class represents the module's configuration when using Salt.
     #
-    # It extends the Configurations::Base class with some
-    # custom attributes (see {#states_url} and {#pillar_url}).
+    # It extends the {Base} class with some Salt specific options. See #post_initialize for further
+    # information about those options.
     class Salt < Base
       # @return [URI,nil] Location of Salt states
       attr_reader :states_url
@@ -19,14 +18,76 @@ module Y2ConfigurationManagement
       # Custom initialization code
       #
       # @param options [Hash] Constructor options
+      # @option options [String] :states_url URL of the states tarball
+      # @option options [String] :pillar_url URL of the pillar data tarball
+      # @option options [String,Pathname] :pillar_root Path to the pillar data directory
+      # @option options [Array<String,Pathname>] :states_roots Path to the states directories
+      # @option options [Array<String,Pathname>] :formulas_roots Path to the formulas directories
+      # @option options [Array<String>] :enabled_states List of enabled Salt states
       def post_initialize(options)
-        @type       = "salt"
+        @type = "salt"
         @states_url = URI(options[:states_url]) if options[:states_url]
         @pillar_url = URI(options[:pillar_url]) if options[:pillar_url]
         @custom_pillar_root = Pathname(options[:pillar_root]) if options[:pillar_root]
         @custom_states_roots = pathnames_from(options[:states_roots])
         @custom_formulas_roots = pathnames_from(options[:formulas_roots])
         @enabled_states = options.fetch(:enabled_states, [])
+      end
+
+      # Return path to the Salt pillars directory
+      #
+      # It takes the `Yast::Installation.destdir` so, when it is different from
+      # "/", you can use the `scope` argument to tell if you want to get the
+      # :local or the :target path.
+      #
+      # @example Default pillars directory
+      #   config = Salt.new
+      #   config.pillar_root #=> #<Pathname:/var/lib/YaST2/cm-202005120829/pillar>
+      #
+      # @example Default pillars directory during installation
+      #   config = Salt.new
+      #   config.pillar_root #=> #<Pathname:/mnt/var/lib/YaST2/cm-202005120829/pillar>
+      #
+      # @example Default pillars directory in :target system during installation
+      #   config = Salt.new
+      #   config.pillar_root(:target) #=> #<Pathname:/var/lib/YaST2/cm-202005120829/pillar>
+      #
+      # @example Using a custom pillar directory
+      #   config = Salt.new(pillar_root: "/srv/salt/custom_pillar")
+      #   config.pillar_root #=> #<Pathname:/srv/salt/custom_pillar>
+      #
+      # @return [Pathname] Path to Salt pillars
+      def pillar_root(scope = :local)
+        return scoped_paths([@custom_pillar_root], scope).first if @custom_pillar_root
+        work_dir(scope).join("pillar")
+      end
+
+      # Return paths to the states root
+      #
+      # It takes the `Yast::Installation.destdir so, when it is different from
+      # "/", you can use the `scope` argument to tell if you want to get the
+      # :local or the :target path.
+      #
+      # @example Default states roots
+      #   config = Salt.new({})
+      #   config.states_roots #=> [#<Pathname:/var/lib/YaST2/cm-202005120908/salt>]
+      #
+      # @example Default states roots during installation
+      #   config = Salt.new
+      #   config.states_root #=> [#<Pathname:/mnt/var/lib/YaST2/cm-202005120908/salt>]
+      #
+      # @example Default states roots in :target system during installation
+      #   config = Salt.new
+      #   config.states_root(:target) #=> [#<Pathname:/var/lib/YaST2/cm-202005120908/salt>]
+      #
+      # @example Custom states roots
+      #   config = Salt.new(states_roots: ["/srv/custom"])
+      #   config.states_roots #=> [#<Pathname:/srv/custom>,
+      #     #<Pathname:/var/lib/YaST2/cm-202005120908/salt>]
+      #
+      # @return [Array<Pathname>] Path to Salt state roots
+      def states_roots(scope = :local)
+        scoped_paths(@custom_states_roots, scope) + [states_root(scope)]
       end
 
       # Return path to the Salt states directory
@@ -36,33 +97,35 @@ module Y2ConfigurationManagement
         work_dir(scope).join("salt")
       end
 
-      # Return path to the Salt pillar directory
-      #
-      # @return [Pathname] Path to Salt pillars
-      def pillar_root(scope = :local)
-        return scoped_paths([@custom_pillar_root], scope).first if @custom_pillar_root
-        work_dir(scope).join("pillar")
-      end
-
-      # Return path to the Salt pillar directory
-      #
-      # @return [Pathname] Path to Salt pillars
-      def formulas_root(scope = :local)
-        work_dir(scope).join("formulas")
-      end
-
-      # Return paths to the states root
-      #
-      # @return [Array<Pathname>] Path to Salt state roots
-      def states_roots(scope = :local)
-        scoped_paths(@custom_states_roots, scope) + [states_root(scope)]
-      end
-
-      # Return paths to the fromulas root
+      # Return paths to all formulas directories
       #
       # @return [Array<Pathname>] Path to Salt formulas roots
       def formulas_roots(scope = :local)
-        scoped_paths(@custom_formulas_roots) + [formulas_root(scope)]
+        scoped_paths(@custom_formulas_roots) + [default_formulas_root(scope)]
+      end
+
+      # Return path to the default Salt formulas directory
+      #
+      # @example Default formulas directory
+      #   config = Salt.new
+      #   config.formulas_root #=> #<Pathname:/var/lib/YaST2/cm-202005120836/formulas>
+      #
+      # @example Default formulas directory during installation
+      #   config = Salt.new
+      #   config.formulas_root #=> #<Pathname:/mnt/var/lib/YaST2/cm-202005120836/formulas>
+      #
+      # @example Default formulas directory in :target system during installation
+      #   config = Salt.new(scope: :target)
+      #   config.formulas_root #=> #<Pathname:/var/lib/YaST2/cm-202005120836/formulas>
+      #
+      # @example Custom states roots
+      #   config = Salt.new(formulas_roots: ["/srv/custom"])
+      #   config.formulas_roots #=> [#<Pathname:/srv/custom>,
+      #     #<Pathname:/var/lib/YaST2/cm-202005120908/formulas>]
+      #
+      # @return [Pathname] Path to Salt formulas
+      def default_formulas_root(scope = :local)
+        work_dir(scope).join("formulas")
       end
 
     private

--- a/src/lib/y2configuration_management/configurations/salt.rb
+++ b/src/lib/y2configuration_management/configurations/salt.rb
@@ -1,4 +1,5 @@
 require "y2configuration_management/configurations/base"
+require "y2configuration_management/configurations/formulas_set"
 require "pathname"
 
 module Y2ConfigurationManagement
@@ -7,6 +8,15 @@ module Y2ConfigurationManagement
     #
     # It extends the {Base} class with some Salt specific options. See #post_initialize for further
     # information about those options.
+    #
+    # The methods that are related to path names ({#states_root}, {#formulas_roots}, {#pillar_root},
+    # {#pillar_roots}, are aware of the scope where YaST is running, so it takes
+    # `Yast::Installation.destdir` into account.
+    #
+    # @example Directories during installation
+    #   config = Salt.new
+    #   config.pillar_roots #=> [#<Pathname:/mnt/var/lib/YaST2/cm-202005120829/pillar>]
+    #   config.pillar_roots(:target) #=> [#<Pathname:/var/lib/YaST2/cm-202005120829/pillar>]
     class Salt < Base
       # @return [URI,nil] Location of Salt states
       attr_reader :states_url
@@ -14,6 +24,33 @@ module Y2ConfigurationManagement
       attr_reader :pillar_url
       # @return [Array<String>] States (including formulas) which will be applied
       attr_reader :enabled_states
+      # @return [Array<FormulasSet>] List of formulas locations
+      attr_reader :formulas_sets
+
+      class << self
+        # Returns a {Salt} object from a hash
+        #
+        # @todo Consider moving this logic elsewhere. Dealing with the import process looks like too
+        #   much for this class.
+        #
+        # @param hash [Hash] Hash containing the options
+        # @return [Salt] Salt configuration instance
+        def new_from_hash(hash)
+          options = Hash[hash.map { |k, v| [k.to_sym, v] }]
+          options[:formulas_sets] = options.fetch(:formulas_sets, []).map do |hsh|
+            FormulasSet.new(hsh["metadata_root"], hsh["states_root"], hsh["pillar_root"])
+          end
+
+          # Support for :formulas_roots option for backward compatibility reasons
+          if options[:formulas_roots]
+            sets = options[:formulas_roots].map { |path| FormulasSet.new(path) }
+            options[:formulas_sets].concat(sets)
+            options.delete(:formulas_roots)
+          end
+
+          new(options)
+        end
+      end
 
       # Custom initialization code
       #
@@ -22,76 +59,53 @@ module Y2ConfigurationManagement
       # @option options [String] :pillar_url URL of the pillar data tarball
       # @option options [String,Pathname] :pillar_root Path to the pillar data directory
       # @option options [Array<String,Pathname>] :states_roots Path to the states directories
-      # @option options [Array<String,Pathname>] :formulas_roots Path to the formulas directories
       # @option options [Array<String>] :enabled_states List of enabled Salt states
+      # @option options [Array<Hash<String,String>>] :formulas_sets Formulas locations
       def post_initialize(options)
         @type = "salt"
         @states_url = URI(options[:states_url]) if options[:states_url]
         @pillar_url = URI(options[:pillar_url]) if options[:pillar_url]
-        @custom_pillar_root = Pathname(options[:pillar_root]) if options[:pillar_root]
+        @custom_pillar_root = Pathname.new(options[:pillar_root]) if options[:pillar_root]
         @custom_states_roots = pathnames_from(options[:states_roots])
-        @custom_formulas_roots = pathnames_from(options[:formulas_roots])
         @enabled_states = options.fetch(:enabled_states, [])
+        @formulas_sets = options.fetch(:formulas_sets, [])
+      end
+
+      # Return path to the Salt main pillars directory (the one containing the top.sls)
+      #
+      # @param scope [Symbol] Path relative to inst-sys (:local) or the
+      #   target system (:target)
+      # @return [Array<Pathname>] Path to Salt pillars
+      def pillar_roots(scope = :local)
+        paths = ([@custom_pillar_root] + formulas_sets.map(&:pillar_root)).compact
+        paths = scoped_paths(paths, scope)
+        paths << pillar_root(scope) unless @custom_pillar_root
+        paths
       end
 
       # Return path to the Salt pillars directory
       #
-      # It takes the `Yast::Installation.destdir` so, when it is different from
-      # "/", you can use the `scope` argument to tell if you want to get the
-      # :local or the :target path.
-      #
-      # @example Default pillars directory
-      #   config = Salt.new
-      #   config.pillar_root #=> #<Pathname:/var/lib/YaST2/cm-202005120829/pillar>
-      #
-      # @example Default pillars directory during installation
-      #   config = Salt.new
-      #   config.pillar_root #=> #<Pathname:/mnt/var/lib/YaST2/cm-202005120829/pillar>
-      #
-      # @example Default pillars directory in :target system during installation
-      #   config = Salt.new
-      #   config.pillar_root(:target) #=> #<Pathname:/var/lib/YaST2/cm-202005120829/pillar>
-      #
-      # @example Using a custom pillar directory
-      #   config = Salt.new(pillar_root: "/srv/salt/custom_pillar")
-      #   config.pillar_root #=> #<Pathname:/srv/salt/custom_pillar>
-      #
+      # @param scope [Symbol] Path relative to inst-sys (:local) or the
+      #   target system (:target)
       # @return [Pathname] Path to Salt pillars
       def pillar_root(scope = :local)
-        return scoped_paths([@custom_pillar_root], scope).first if @custom_pillar_root
         work_dir(scope).join("pillar")
       end
 
       # Return paths to the states root
       #
-      # It takes the `Yast::Installation.destdir so, when it is different from
-      # "/", you can use the `scope` argument to tell if you want to get the
-      # :local or the :target path.
-      #
-      # @example Default states roots
-      #   config = Salt.new({})
-      #   config.states_roots #=> [#<Pathname:/var/lib/YaST2/cm-202005120908/salt>]
-      #
-      # @example Default states roots during installation
-      #   config = Salt.new
-      #   config.states_root #=> [#<Pathname:/mnt/var/lib/YaST2/cm-202005120908/salt>]
-      #
-      # @example Default states roots in :target system during installation
-      #   config = Salt.new
-      #   config.states_root(:target) #=> [#<Pathname:/var/lib/YaST2/cm-202005120908/salt>]
-      #
-      # @example Custom states roots
-      #   config = Salt.new(states_roots: ["/srv/custom"])
-      #   config.states_roots #=> [#<Pathname:/srv/custom>,
-      #     #<Pathname:/var/lib/YaST2/cm-202005120908/salt>]
-      #
+      # @param scope [Symbol] Path relative to inst-sys (:local) or the
+      #   target system (:target)
       # @return [Array<Pathname>] Path to Salt state roots
       def states_roots(scope = :local)
-        scoped_paths(@custom_states_roots, scope) + [states_root(scope)]
+        paths = @custom_states_roots + formulas_sets.map(&:states_root).compact
+        scoped_paths(paths, scope) + [states_root(scope)]
       end
 
       # Return path to the Salt states directory
       #
+      # @param scope [Symbol] Path relative to inst-sys (:local) or the
+      #   target system (:target)
       # @return [Pathname] Path to Salt states
       def states_root(scope = :local)
         work_dir(scope).join("salt")
@@ -99,30 +113,19 @@ module Y2ConfigurationManagement
 
       # Return paths to all formulas directories
       #
+      # @param scope [Symbol] Path relative to inst-sys (:local) or the
+      #   target system (:target)
       # @return [Array<Pathname>] Path to Salt formulas roots
       def formulas_roots(scope = :local)
-        scoped_paths(@custom_formulas_roots) + [default_formulas_root(scope)]
+        paths = formulas_sets.map(&:metadata_root).compact
+        scoped_paths(paths, scope) + [default_formulas_root(scope)]
       end
 
       # Return path to the default Salt formulas directory
       #
-      # @example Default formulas directory
-      #   config = Salt.new
-      #   config.formulas_root #=> #<Pathname:/var/lib/YaST2/cm-202005120836/formulas>
       #
-      # @example Default formulas directory during installation
-      #   config = Salt.new
-      #   config.formulas_root #=> #<Pathname:/mnt/var/lib/YaST2/cm-202005120836/formulas>
-      #
-      # @example Default formulas directory in :target system during installation
-      #   config = Salt.new(scope: :target)
-      #   config.formulas_root #=> #<Pathname:/var/lib/YaST2/cm-202005120836/formulas>
-      #
-      # @example Custom states roots
-      #   config = Salt.new(formulas_roots: ["/srv/custom"])
-      #   config.formulas_roots #=> [#<Pathname:/srv/custom>,
-      #     #<Pathname:/var/lib/YaST2/cm-202005120908/formulas>]
-      #
+      # @param scope [Symbol] Path relative to inst-sys (:local) or the
+      #   target system (:target)
       # @return [Pathname] Path to Salt formulas
       def default_formulas_root(scope = :local)
         work_dir(scope).join("formulas")

--- a/src/lib/y2configuration_management/configurators/salt.rb
+++ b/src/lib/y2configuration_management/configurators/salt.rb
@@ -77,12 +77,8 @@ module Y2ConfigurationManagement
         if config.master.is_a?(::String)
           config_file.master = config.master
         else
-          config_file.set_file_roots(
-            config.states_roots(:target) + config.formulas_roots(:target)
-          )
-          config_file.set_pillar_roots(
-            config.pillar_roots(:target)
-          )
+          config_file.set_file_roots(config.states_roots(:target))
+          config_file.set_pillar_roots(config.pillar_roots(:target))
         end
         config_file.save
       end

--- a/src/lib/y2configuration_management/configurators/salt.rb
+++ b/src/lib/y2configuration_management/configurators/salt.rb
@@ -80,6 +80,9 @@ module Y2ConfigurationManagement
           config_file.set_file_roots(
             config.states_roots(:target) + config.formulas_roots(:target)
           )
+          config_file.set_pillar_roots(
+            config.pillar_roots(:target)
+          )
         end
         config_file.save
       end

--- a/src/lib/y2configuration_management/runners/base.rb
+++ b/src/lib/y2configuration_management/runners/base.rb
@@ -5,6 +5,10 @@ require "cheetah"
 Yast.import "Installation"
 
 module Y2ConfigurationManagement
+  # This classes in this module are responsible for running the provisioning tools (Salt or Puppet).
+  #
+  # As usual, the {Base} class defines the common bits, while {Salt} and {Puppet} implement the
+  # suport for Salt and Puppet provisioners.
   module Runners
     class UnknownRunner < StandardError; end
 

--- a/src/lib/y2configuration_management/runners/salt.rb
+++ b/src/lib/y2configuration_management/runners/salt.rb
@@ -31,8 +31,7 @@ module Y2ConfigurationManagement
       # @see Y2ConfigurationManagement::Runners::Base#run_masterless_mode
       def run_masterless_mode(stdout, stderr)
         with_retries(config.auth_attempts, config.auth_time_out) do
-          run_cmd("salt-call", "--log-level", "debug", "--local",
-            "--pillar-root=#{config.pillar_root(:target)}", "state.highstate",
+          run_cmd("salt-call", "--log-level", "debug", "--local", "state.highstate",
             stdout: stdout, stderr: stderr)
         end
       end

--- a/src/lib/y2configuration_management/salt/formula.rb
+++ b/src/lib/y2configuration_management/salt/formula.rb
@@ -23,6 +23,7 @@ require "fileutils"
 require "y2configuration_management/salt/form"
 require "y2configuration_management/salt/metadata"
 require "y2configuration_management/salt/pillar"
+require "y2configuration_management/salt/formulas_reader"
 
 module Y2ConfigurationManagement
   module Salt
@@ -64,13 +65,7 @@ module Y2ConfigurationManagement
         # @return [Array<Formula>]
         def all(*paths, reload: false)
           return @formulas if @formulas && !reload
-          metadata_paths = paths.flatten.compact.empty? ? formula_directories : paths.flatten.compact
-          @formulas =
-            Dir.glob(metadata_paths.map { |p| p + "/*" })
-              .map { |p| Pathname.new(p) }
-              .select(&:directory?)
-              .map { |p| Formula.new(p) }
-              .select(&:form)
+          @formulas = FormulasReader.new(paths).formulas
         end
 
         # Return formula default directories

--- a/src/lib/y2configuration_management/salt/formula.rb
+++ b/src/lib/y2configuration_management/salt/formula.rb
@@ -33,15 +33,6 @@ module Y2ConfigurationManagement
     class Formula
       include Yast::Logger
 
-      # Default path to formulas repository. SuMa *-formula.rpm put them there
-      BASE_DIR = "/usr/share/susemanager/formulas".freeze
-      # Custom formulas metadada directory
-      # @see https://www.suse.com/documentation/suse-manager-3/singlehtml/book_suma_best_practices_31/book_suma_best_practices_31.html#best.practice.salt.formulas.filedir
-      CUSTOM_METADATA_DIR = "/srv/formula_metadata".freeze
-      # Saved data directory
-      # @see https://www.suse.com/documentation/suse-manager-3/singlehtml/book_suma_best_practices_31/book_suma_best_practices_31.html#best.practice.salt.formulas.req
-      DATA_DIR = "/srv/susemanager/formula_data".freeze
-
       # @return [Pathname] Formula path
       attr_reader :path
 
@@ -65,14 +56,7 @@ module Y2ConfigurationManagement
         # @return [Array<Formula>]
         def all(*paths, reload: false)
           return @formulas if @formulas && !reload
-          @formulas = FormulasReader.new(paths).formulas
-        end
-
-        # Return formula default directories
-        #
-        # @return [String]
-        def formula_directories
-          [BASE_DIR + "/metadata", CUSTOM_METADATA_DIR]
+          @formulas = FormulasReader.new(*paths).formulas
         end
       end
 

--- a/src/lib/y2configuration_management/salt/formula.rb
+++ b/src/lib/y2configuration_management/salt/formula.rb
@@ -45,21 +45,6 @@ module Y2ConfigurationManagement
       # @return [Pillar] Formula pillar
       attr_accessor :pillar
 
-      class << self
-        # Return all the installed formulas
-        #
-        # @note The result is cached. To force refreshing the cache, set the `reload`
-        #   parameter to `true`.
-        #
-        # @param paths  [Array<String>|String] File system paths to search for formulas
-        # @param reload [Boolean] Refresh formulas cache
-        # @return [Array<Formula>]
-        def all(*paths, reload: false)
-          return @formulas if @formulas && !reload
-          @formulas = FormulasReader.new(*paths).formulas
-        end
-      end
-
       # Constructor
       #
       # @param path [Pathname]

--- a/src/lib/y2configuration_management/salt/formula_sequence.rb
+++ b/src/lib/y2configuration_management/salt/formula_sequence.rb
@@ -20,7 +20,7 @@
 require "ui/sequence"
 require "y2configuration_management/salt/formula_configuration"
 require "y2configuration_management/salt/formula_selection"
-require "y2configuration_management/salt/formula"
+require "y2configuration_management/salt/formulas_reader"
 require "y2configuration_management/cfa/salt_top"
 
 Yast.import "Report"
@@ -127,20 +127,12 @@ module Y2ConfigurationManagement
       # It reads all the available {Formula}s in the system initializing also
       # the {Pillar} associated with each one
       def read_formulas
-        @formulas = Y2ConfigurationManagement::Salt::Formula.all(config.formulas_roots.map(&:to_s))
-        @formulas.each { |f| f.pillar = pillar_for(f) }
-      end
-
-      # Convenience method for reading the {Pillar} associated to the given
-      # formula
-      #
-      # @param formula [Formula]
-      # @return [Pillar]
-      def pillar_for(formula)
-        pillar_file = File.join(config.pillar_root, "#{formula.id}.sls")
-        pillar = Y2ConfigurationManagement::Salt::Pillar.new(data: {}, path: pillar_file)
-        pillar.load
-        pillar
+        @formulas = config.formulas_sets.each_with_object([]) do |location, formulas|
+          reader = Y2ConfigurationManagement::Salt::FormulasReader.new(
+            location.metadata_root, location.pillar_root || config.pillar_root
+          )
+          formulas.concat(reader.formulas)
+        end
       end
 
       # Asks the user to select the enabled formulas/states

--- a/src/lib/y2configuration_management/salt/formula_sequence.rb
+++ b/src/lib/y2configuration_management/salt/formula_sequence.rb
@@ -33,7 +33,7 @@ module Y2ConfigurationManagement
   module Salt
     # This class is reponsible of running the sequence for selecting the Salt
     # {Formula}s to be applied, configuring all the {Formula}s through its
-    # {Form}s and write the {Pillar}s data associated to each of the selected
+    # {Form}s and writing the {Pillar}s data associated to each of the selected
     # {Formula}s into the system.
     class FormulaSequence < UI::Sequence
       # @return [Array<Formula>] available on the system

--- a/src/lib/y2configuration_management/salt/formulas_reader.rb
+++ b/src/lib/y2configuration_management/salt/formulas_reader.rb
@@ -1,0 +1,55 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2configuration_management/salt/formula"
+
+module Y2ConfigurationManagement
+  module Salt
+    # Reads formulas from a set of given directories
+    #
+    # @example Reading SUMA formulas
+    #   reader = FormulasReader.new("/usr/share/susemanager/formulas/metadata")
+    #   reader.formulas #=> [#<Formula:...>, #<Formula:...>]
+    #
+    # @example Reading formulas from several locations
+    #   reader = FormulasReader.new(["/usr/share/susemanager/formulas/metadata", "/srv/formulas"])
+    #   reader.formulas #=> [#<Formula:...>, #<Formula:...>]
+    class FormulasReader
+      # @return [Array<String>] Paths to read formulas from
+      attr_reader :paths
+
+      # Constructor
+      #
+      # @param paths  [Array<String>|String] File system paths to search for formulas
+      def initialize(*paths)
+        @paths = paths
+      end
+
+      # @return [Array<Formula>]
+      def formulas
+        metadata_paths = paths.flatten.compact.empty? ? formula_directories : paths.flatten.compact
+        Dir.glob(metadata_paths.map { |p| p + "/*" })
+          .map { |p| Pathname.new(p) }
+          .select(&:directory?)
+          .map { |p| Formula.new(p) }
+          .select(&:form)
+      end
+    end
+  end
+end

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -20,6 +20,7 @@
 srcdir = File.expand_path("../../src", __FILE__)
 y2dirs = ENV.fetch("Y2DIR", "").split(":")
 ENV["Y2DIR"] = y2dirs.unshift(srcdir).join(":")
+ENV["LC_ALL"] = "en_US.UTF-8"
 
 require "yast"
 require "pathname"

--- a/test/y2configuration_management/cfa/minion_test.rb
+++ b/test/y2configuration_management/cfa/minion_test.rb
@@ -81,6 +81,22 @@ describe Y2ConfigurationManagement::CFA::Minion do
       end
     end
 
+    describe "#set_pillar_roots" do
+      it "sets the pillar-roots for the base environment" do
+        config.set_pillar_roots(["/srv/pillar"])
+        expect(config.pillar_roots("base")).to eq(["/srv/pillar"])
+      end
+
+      context "when an environment is specified" do
+        it "sets pillar_roots for the given environment" do
+          old = config.pillar_roots("base")
+          config.set_pillar_roots(["/srv/pillar"], "test")
+          expect(config.pillar_roots("base")).to eq(old)
+          expect(config.pillar_roots("test")).to eq(["/srv/pillar"])
+        end
+      end
+    end
+
     describe "#exist?" do
       context "when the file exists" do
         let(:path) { EXAMPLE_PATH }

--- a/test/y2configuration_management/clients/auto_client_test.rb
+++ b/test/y2configuration_management/clients/auto_client_test.rb
@@ -10,10 +10,10 @@ describe Y2ConfigurationManagement::AutoClient do
   let(:configurator) { double("configurator", packages: packages) }
   let(:packages) { { "install" => ["pkg1"] } }
   let(:profile) { { "type" => "salt", "master" => "myserver" } }
-  let(:config) { Y2ConfigurationManagement::Configurations::Base.for(profile) }
+  let(:config) { Y2ConfigurationManagement::Configurations::Base.from_hash(profile) }
 
   before do
-    allow(Y2ConfigurationManagement::Configurations::Base).to receive(:for).with(profile)
+    allow(Y2ConfigurationManagement::Configurations::Base).to receive(:from_hash).with(profile)
       .and_return(config)
   end
 

--- a/test/y2configuration_management/clients/main_test.rb
+++ b/test/y2configuration_management/clients/main_test.rb
@@ -59,7 +59,7 @@ describe Y2ConfigurationManagement::Clients::Main do
       let(:file_exists?) { false }
 
       it "uses the default_settings" do
-        expect(configuration).to receive(:for)
+        expect(configuration).to receive(:from_hash)
           .with(described_class::DEFAULT_SETTINGS).and_call_original
 
         main.run
@@ -70,7 +70,7 @@ describe Y2ConfigurationManagement::Clients::Main do
       let(:filename) { nil }
 
       it "uses the default_settings" do
-        expect(configuration).to receive(:for)
+        expect(configuration).to receive(:from_hash)
           .with(described_class::DEFAULT_SETTINGS).and_call_original
 
         main.run
@@ -81,7 +81,7 @@ describe Y2ConfigurationManagement::Clients::Main do
       let(:config) { nil }
 
       it "uses the default_settings" do
-        expect(configuration).to receive(:for)
+        expect(configuration).to receive(:from_hash)
           .with(described_class::DEFAULT_SETTINGS).and_call_original
 
         main.run

--- a/test/y2configuration_management/configurations/base_test.rb
+++ b/test/y2configuration_management/configurations/base_test.rb
@@ -13,11 +13,11 @@ describe Y2ConfigurationManagement::Configurations::Base do
 
   let(:profile) do
     {
-      "type"          => "salt",
-      "master"        => master,
-      "auth_attempts" => 5,
-      "auth_time_out" => 10,
-      "keys_url"      => "http://internal-server.com/keys.tgz"
+      type:          "salt",
+      master:        master,
+      auth_attempts: 5,
+      auth_time_out: 10,
+      keys_url:      "http://internal-server.com/keys.tgz"
     }
   end
 

--- a/test/y2configuration_management/configurations/puppet_test.rb
+++ b/test/y2configuration_management/configurations/puppet_test.rb
@@ -5,15 +5,15 @@ require "y2configuration_management/configurations/puppet"
 require "tmpdir"
 
 describe Y2ConfigurationManagement::Configurations::Puppet do
-  subject(:config) { Y2ConfigurationManagement::Configurations::Puppet.new(profile) }
+  subject(:config) { described_class.new_from_hash(hash) }
 
   let(:master) { "puppet.suse.de" }
   let(:modules_url) { "http://ftp.suse.de/modules.tgz" }
 
-  let(:profile) do
+  let(:hash) do
     {
-      master:      master,
-      modules_url: modules_url
+      "master"      => master,
+      "modules_url" => modules_url
     }
   end
 

--- a/test/y2configuration_management/configurations/salt_test.rb
+++ b/test/y2configuration_management/configurations/salt_test.rb
@@ -89,15 +89,6 @@ describe Y2ConfigurationManagement::Configurations::Salt do
   end
 
   describe "#pillar_roots" do
-    it "returns states roots (custom, formulas and work_dir + 'salt')" do
-      expect(config.states_roots.map(&:to_s))
-        .to contain_exactly(
-          "/srv/custom_states", formulas_sets[0]["states_root"], /#{config.work_dir}/
-        )
-    end
-  end
-
-  describe "#pillar_roots" do
     it "returns pillar roots (formulas and work_dir)" do
       expect(config.pillar_roots.map(&:to_s))
         .to contain_exactly("/srv/susemanager/formulas_data", /#{config.work_dir}/)

--- a/test/y2configuration_management/configurations/salt_test.rb
+++ b/test/y2configuration_management/configurations/salt_test.rb
@@ -48,6 +48,25 @@ describe Y2ConfigurationManagement::Configurations::Salt do
         )
       )
     end
+
+    context "when the old 'formulas_roots' key is used" do
+      let(:hash) do
+        {
+          "master"         => master,
+          "formulas_roots" => [
+            "/srv/custom_formulas"
+          ]
+        }
+      end
+      it "returns a FormulaSet object for each 'formulas_roots' element" do
+        config = described_class.new_from_hash(hash)
+        expect(config.formulas_sets).to contain_exactly(
+          an_object_having_attributes(
+            metadata_root: Pathname.new(hash["formulas_roots"].first)
+          )
+        )
+      end
+    end
   end
 
   describe "#type" do

--- a/test/y2configuration_management/configurations/salt_test.rb
+++ b/test/y2configuration_management/configurations/salt_test.rb
@@ -5,22 +5,61 @@ require "y2configuration_management/configurations/salt"
 require "tmpdir"
 
 describe Y2ConfigurationManagement::Configurations::Salt do
-  subject(:config) { Y2ConfigurationManagement::Configurations::Salt.new(profile) }
+  subject(:config) { described_class.new_from_hash(hash) }
 
   let(:master) { "puppet.suse.de" }
   let(:states_url) { "http://ftp.suse.de/modules.tgz" }
 
-  let(:profile) do
+  let(:hash) do
     {
-      master:         master,
-      states_url:     URI(states_url),
-      enabled_states: ["motd"]
+      "master"         => master,
+      "states_url"     => URI(states_url),
+      "formulas_sets"  => formulas_sets,
+      "enabled_states" => ["motd"],
+      "states_roots"   => ["/srv/custom_states"]
     }
+  end
+
+  let(:formulas_sets) do
+    [
+      { "metadata_root" => "/usr/share/susemanager/formulas/metadata",
+        "states_root"   => "/usr/share/susemanager/formulas/states",
+        "pillar_root"   => "/srv/susemanager/formulas_data" },
+      { "metadata_root" => "/srv/custom_formulas" }
+    ]
+  end
+
+  describe ".new_from_hash" do
+    it "returns  a configuration from the given hash" do
+      config = described_class.new_from_hash(hash)
+      expect(config.master).to eq(master)
+    end
+
+    it "includes the formulas sets" do
+      config = described_class.new_from_hash(hash)
+      expect(config.formulas_sets).to contain_exactly(
+        an_object_having_attributes(
+          metadata_root: Pathname.new(formulas_sets[0]["metadata_root"]),
+          states_root:   Pathname.new(formulas_sets[0]["states_root"]),
+          pillar_root:   Pathname.new(formulas_sets[0]["pillar_root"])
+        ),
+        an_object_having_attributes(
+          metadata_root: Pathname.new(formulas_sets[1]["metadata_root"])
+        )
+      )
+    end
   end
 
   describe "#type" do
     it "returns 'salt'" do
       expect(config.type).to eq("salt")
+    end
+  end
+
+  describe "#states_roots" do
+    it "returns states roots (custom, formulas and work_dir + 'salt')" do
+      expect(config.states_roots.map(&:to_s))
+        .to contain_exactly("/srv/custom_states", formulas_sets[0]["states_root"], /var/)
     end
   end
 
@@ -30,9 +69,34 @@ describe Y2ConfigurationManagement::Configurations::Salt do
     end
   end
 
-  describe "#pillar_root" do
-    it "returns work_dir + 'pillar'" do
-      expect(config.pillar_root).to eq(config.work_dir.join("pillar"))
+  describe "#pillar_roots" do
+    it "returns states roots (custom, formulas and work_dir + 'salt')" do
+      expect(config.states_roots.map(&:to_s))
+        .to contain_exactly(
+          "/srv/custom_states", formulas_sets[0]["states_root"], /#{config.work_dir}/
+        )
+    end
+  end
+
+  describe "#pillar_roots" do
+    it "returns pillar roots (formulas and work_dir)" do
+      expect(config.pillar_roots.map(&:to_s))
+        .to contain_exactly("/srv/susemanager/formulas_data", /#{config.work_dir}/)
+    end
+
+    context "when the pillar_root is set" do
+      let(:hash) do
+        {
+          "master"        => master,
+          "formulas_sets" => formulas_sets,
+          "pillar_root"   => "/srv/pillar"
+        }
+      end
+
+      it "returns the pillar_root instead of the one in the work_dir" do
+        expect(config.pillar_roots.map(&:to_s))
+          .to contain_exactly("/srv/susemanager/formulas_data", "/srv/pillar")
+      end
     end
   end
 
@@ -42,7 +106,7 @@ describe Y2ConfigurationManagement::Configurations::Salt do
     end
 
     context "when on states have been enabled" do
-      let(:profile) { {} }
+      let(:hash) { {} }
 
       it "returns an empty array" do
         expect(config.enabled_states).to eq([])

--- a/test/y2configuration_management/configurators/salt_test.rb
+++ b/test/y2configuration_management/configurators/salt_test.rb
@@ -105,7 +105,7 @@ describe Y2ConfigurationManagement::Configurators::Salt do
 
       it "sets file_roots in the minion's configuration" do
         expect(minion_config).to receive(:set_file_roots)
-          .with([config.states_root(:target)] + config.formulas_roots(:target))
+          .with([config.states_root(:target)])
         configurator.prepare
       end
 

--- a/test/y2configuration_management/configurators/salt_test.rb
+++ b/test/y2configuration_management/configurators/salt_test.rb
@@ -82,6 +82,7 @@ describe Y2ConfigurationManagement::Configurators::Salt do
         allow(Y2ConfigurationManagement::CFA::Minion)
           .to receive(:new).and_return(minion_config)
         allow(minion_config).to receive(:set_file_roots)
+        allow(minion_config).to receive(:set_pillar_roots)
         allow(configurator).to receive(:fetch_config)
         allow(Yast::WFM).to receive(:CallFunction)
         allow(Y2ConfigurationManagement::Salt::FormulaSequence).to receive(:new)
@@ -105,6 +106,12 @@ describe Y2ConfigurationManagement::Configurators::Salt do
       it "sets file_roots in the minion's configuration" do
         expect(minion_config).to receive(:set_file_roots)
           .with([config.states_root(:target)] + config.formulas_roots(:target))
+        configurator.prepare
+      end
+
+      it "sets pillar_roots in the minion's configuration" do
+        expect(minion_config).to receive(:set_pillar_roots)
+          .with(config.pillar_roots(:target))
         configurator.prepare
       end
     end

--- a/test/y2configuration_management/configurators/salt_test.rb
+++ b/test/y2configuration_management/configurators/salt_test.rb
@@ -104,7 +104,7 @@ describe Y2ConfigurationManagement::Configurators::Salt do
 
       it "sets file_roots in the minion's configuration" do
         expect(minion_config).to receive(:set_file_roots)
-          .with([config.states_root(:target), config.formulas_root(:target)])
+          .with([config.states_root(:target)] + config.formulas_roots(:target))
         configurator.prepare
       end
     end

--- a/test/y2configuration_management/runners/salt_test.rb
+++ b/test/y2configuration_management/runners/salt_test.rb
@@ -49,8 +49,7 @@ describe Y2ConfigurationManagement::Runners::Salt do
       it "runs salt-call" do
         expect(Cheetah).to receive(:run).with(
           "salt-call", "--log-level", "debug",
-          "--local", "--pillar-root=#{config.pillar_root(:target)}",
-          "state.highstate",
+          "--local", "state.highstate",
           stdout: $stdout, stderr: $stderr, chroot: "/mnt"
         )
         expect(runner.run).to eq(true)

--- a/test/y2configuration_management/salt/formula_configuration_test.rb
+++ b/test/y2configuration_management/salt/formula_configuration_test.rb
@@ -21,13 +21,16 @@
 
 require_relative "../../spec_helper"
 require "y2configuration_management/salt/formula_configuration"
-require "y2configuration_management/salt/formula"
+require "y2configuration_management/salt/formulas_reader"
 
 require "cwm/rspec"
 
 describe Y2ConfigurationManagement::Salt::FormulaConfiguration do
   let(:formulas_root) { FIXTURES_PATH.join("formulas-ng") }
-  let(:formulas) { Y2ConfigurationManagement::Salt::Formula.all(formulas_root.to_s, reload: true) }
+  let(:pillar_root) { FIXTURES_PATH.join("pillar") }
+  let(:formulas) do
+    Y2ConfigurationManagement::Salt::FormulasReader.new(formulas_root, pillar_root).formulas
+  end
   let(:formula) { formulas[0] }
   let(:controller) do
     instance_double("Y2ConfigurationManagement::Salt::FormController", show_main_dialog: :cancel)

--- a/test/y2configuration_management/salt/formula_selection_test.rb
+++ b/test/y2configuration_management/salt/formula_selection_test.rb
@@ -28,9 +28,10 @@ require "cwm/rspec"
 describe Y2ConfigurationManagement::Salt::FormulaSelection do
   include_examples "CWM::Dialog"
   let(:formulas_root) { FIXTURES_PATH.join("formulas-ng") }
+  let(:pillar_root) { FIXTURES_PATH.join("pillar") }
   let(:form) { formulas_root.join("form.yml") }
   let(:formulas) do
-    Y2ConfigurationManagement::Salt::Formula.all(formulas_root.to_s, reload: true)
+    Y2ConfigurationManagement::Salt::FormulasReader.new(formulas_root, pillar_root).formulas
   end
 
   subject { described_class.new(formulas) }

--- a/test/y2configuration_management/salt/formula_test.rb
+++ b/test/y2configuration_management/salt/formula_test.rb
@@ -20,35 +20,27 @@
 
 require_relative "../../spec_helper"
 require "y2configuration_management/salt/formula"
+require "y2configuration_management/salt/formulas_reader"
 
 describe Y2ConfigurationManagement::Salt::Formula do
-  let(:formulas) do
-    described_class.all(FIXTURES_PATH.join("formulas-ng").to_s, reload: true)
-  end
-
-  describe ".all" do
-    it "returns all formulas from the given directory" do
-      formulas = described_class.all(FIXTURES_PATH.join("formulas-ng").to_s, reload: true)
-      expect(formulas.size).to eql(2)
-    end
-  end
+  subject(:formula) { described_class.new(path) }
+  let(:path) { FIXTURES_PATH.join("formulas-ng", "test-formula") }
 
   describe "#description" do
     it "returns the formula description from the metadata" do
-      formula = formulas.find { |f| f.id == "test-formula" }
       expect(formula.description).to include("This is the description of the test formula")
     end
 
     context "when the formula does not have metadata" do
+      let(:path) { FIXTURES_PATH.join("formulas-ng", "no-metadata") }
+
       it "returns an empty string" do
-        formula = formulas.find { |f| f.id == "no-metadata" }
         expect(formula.description).to be_empty
       end
     end
   end
 
   describe "#write_pillar" do
-    let(:formula) { formulas.find { |f| f.id == "test-formula" } }
     let(:pillar_path) { FIXTURES_PATH.join("pillar").join("test-formula.sls") }
     let(:pillar) { Y2ConfigurationManagement::Salt::Pillar.from_file(pillar_path) }
 

--- a/test/y2configuration_management/salt/formula_test.rb
+++ b/test/y2configuration_management/salt/formula_test.rb
@@ -22,30 +22,22 @@ require_relative "../../spec_helper"
 require "y2configuration_management/salt/formula"
 
 describe Y2ConfigurationManagement::Salt::Formula do
-  let(:formulas) { described_class.all(FIXTURES_PATH.join("formulas-ng").to_s, reload: true) }
+  let(:formulas) do
+    described_class.all(FIXTURES_PATH.join("formulas-ng").to_s, reload: true)
+  end
 
   describe ".all" do
-    it "returns all the formulas from the given path" do
+    it "returns all formulas from the given directory" do
+      formulas = described_class.all(FIXTURES_PATH.join("formulas-ng").to_s, reload: true)
       expect(formulas.size).to eql(2)
-    end
-
-    context "when a formula does not contain a metadata file" do
-      it "is returned anyway" do
-        expect(formulas.map(&:id)).to include("no-metadata")
-      end
-    end
-
-    context "when a formula does not contain a form" do
-      it "is skipped" do
-        expect(formulas.map(&:id)).to_not include("no-one")
-      end
     end
 
     context "when no path is given" do
       let(:formulas) { described_class.all }
 
       before do
-        allow(described_class).to receive(:formula_directories)
+        allow(described_class)
+          .to receive(:formula_directories)
           .and_return([FIXTURES_PATH.join("formulas-ng").to_s])
       end
 

--- a/test/y2configuration_management/salt/formula_test.rb
+++ b/test/y2configuration_management/salt/formula_test.rb
@@ -31,30 +31,6 @@ describe Y2ConfigurationManagement::Salt::Formula do
       formulas = described_class.all(FIXTURES_PATH.join("formulas-ng").to_s, reload: true)
       expect(formulas.size).to eql(2)
     end
-
-    context "when no path is given" do
-      let(:formulas) { described_class.all }
-
-      before do
-        allow(described_class)
-          .to receive(:formula_directories)
-          .and_return([FIXTURES_PATH.join("formulas-ng").to_s])
-      end
-
-      it "returns all the formulas from the default directories" do
-        expect(formulas.size).to eql(2)
-      end
-    end
-  end
-
-  describe ".formula_directories" do
-    let(:default_directories) do
-      [described_class::BASE_DIR + "/metadata", described_class::CUSTOM_METADATA_DIR]
-    end
-
-    it "returns an array with the default formula directories" do
-      expect(described_class.formula_directories).to eql(default_directories)
-    end
   end
 
   describe "#description" do

--- a/test/y2configuration_management/salt/formulas_reader_test.rb
+++ b/test/y2configuration_management/salt/formulas_reader_test.rb
@@ -22,7 +22,9 @@ require "y2configuration_management/salt/formulas_reader"
 
 describe Y2ConfigurationManagement::Salt::FormulasReader do
   subject(:reader) do
-    described_class.new(FIXTURES_PATH.join("formulas-ng").to_s)
+    described_class.new(
+      FIXTURES_PATH.join("formulas-ng"), FIXTURES_PATH.join("pillar")
+    )
   end
 
   describe "#formulas" do

--- a/test/y2configuration_management/salt/formulas_reader_test.rb
+++ b/test/y2configuration_management/salt/formulas_reader_test.rb
@@ -1,0 +1,45 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../spec_helper"
+require "y2configuration_management/salt/formulas_reader"
+
+describe Y2ConfigurationManagement::Salt::FormulasReader do
+  subject(:reader) do
+    described_class.new(FIXTURES_PATH.join("formulas-ng").to_s)
+  end
+
+  describe "#formulas" do
+    it "returns all the formulas from the given path" do
+      expect(reader.formulas.size).to eql(2)
+    end
+
+    context "when a formula does not contain a metadata file" do
+      it "is returned anyway" do
+        expect(reader.formulas.map(&:id)).to include("no-metadata")
+      end
+    end
+
+    context "when a formula does not contain a form" do
+      it "is skipped" do
+        expect(reader.formulas.map(&:id)).to_not include("no-one")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR is part of a set of fixes for [bsc#1169410](https://bugzilla.suse.com/show_bug.cgi?id=1169410). I will open an additional PR to solve the rest of the problems, as the current one includes several internal improvements and it might be hard to review.

## Support for multiple Pillars

Until now, the module supported to specify several directories to read formulas from. However, it used a single location to save Pillar data (by default, `/srv/susemanager/formula_data/pillar`. Now, when using formulas, it is possible to specify the metadata, the states and the pillar directories for each set of formulas (see `formulas_sets` element below).

```xml
  <configuration_management>
    <type>salt</type>
    <!-- Default Salt Formulas directories -->
    <formulas_sets config:type="list">
      <listentry>
        <metadata_root>/usr/share/susemanager/formulas/metadata</metadata_root>
        <states_root>/usr/share/susemanager/formulas/states</states_root>
        <pillar_root>/srv/susemanager/formula_data</pillar_root>
      </listentry>
      <listentry>
        <metadata_root>/usr/share/salt-formulas/metadata</metadata_root>
        <states_root>/usr/share/salt-formulas/states</states_root>
        <pillar_root>/srv/salt-formulas/pillar</pillar_root>
      </listentry>
      <listentry>
        <metadata_root>/srv/formula_metadata</metadata_root>
      </listentry>
    </formulas_sets>
    <!-- Default Salt Formulas pillar data directory  -->
    <pillar_root>/srv/susemanager/formula_data</pillar_root>
  </configuration_management>
```
## TODO (separate PRs)

- [ ] Move the defaults to a YAML (or an XML) file.
- [x] Review `file_roots` and `pillar_roots` ordering.

## References

Trello: https://trello.com/c/S7XSVGWs/
Bug report: https://bugzilla.suse.com/show_bug.cgi?id=1169410