### PR TITLE
bsc#1177522: clean-up libzypp's raw cache

### DIFF
--- a/package/yast2-configuration-management.changes
+++ b/package/yast2-configuration-management.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Sat Oct 10 08:47:44 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Clean-up the libzypp's raw cache before running the finish client
+  (bsc#1177522).
+- 4.2.6
+
+-------------------------------------------------------------------
 Thu May 21 21:20:44 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - bsc#1169410:

--- a/package/yast2-configuration-management.spec
+++ b/package/yast2-configuration-management.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-configuration-management
-Version:        4.2.5
+Version:        4.2.6
 Release:        0
 Url:            https://github.com/yast/yast-migration
 Summary:        YaST2 - YaST Configuration Management

--- a/src/lib/y2configuration_management/clients/configuration_management_finish.rb
+++ b/src/lib/y2configuration_management/clients/configuration_management_finish.rb
@@ -32,6 +32,11 @@ module Y2ConfigurationManagement
       return false if config.nil?
       Yast::Wizard.CreateDialog
       log.info("Provisioning Configuration Management with config #{config.inspect}")
+
+      # We need the raw cache to be clean in order to do "zypper ref --force".
+      # Otherwise, the operation will fail.
+      ::FileUtils.rm_r(ZYPP_RAW_CACHE) if Dir.exist?(ZYPP_RAW_CACHE)
+
       configurator.prepare(require_formulas: false)
       # saving settings to target system
       Y2ConfigurationManagement::Clients::Provision.new.run
@@ -54,6 +59,8 @@ module Y2ConfigurationManagement
     end
 
   private
+
+    ZYPP_RAW_CACHE = File.join(Yast::Installation.destdir, "var", "cache", "zypp", "raw")
 
     def configurator
       @configurator ||= Y2ConfigurationManagement::Configurators::Base.current

--- a/src/lib/y2configuration_management/clients/configuration_management_finish.rb
+++ b/src/lib/y2configuration_management/clients/configuration_management_finish.rb
@@ -34,7 +34,7 @@ module Y2ConfigurationManagement
       log.info("Provisioning Configuration Management with config #{config.inspect}")
 
       # We need the raw cache to be clean in order to do "zypper ref --force".
-      # Otherwise, the operation will fail.
+      # Otherwise, the operation will fail (bsc#1177522).
       ::FileUtils.rm_r(ZYPP_RAW_CACHE) if Dir.exist?(ZYPP_RAW_CACHE)
 
       configurator.prepare(require_formulas: false)


### PR DESCRIPTION
For some reason, if the cache is not cleaned, calling `zypper --non-interactive ref --upgrade` (as done by Salt) produces an error when calling `repo2solv`. I tried just calling `zypper cc`, but it does not remove the metadata for the DVD repository.

```
'repo2solv' '-o' '/var/cache/zypp/solv/SLES15-SP2-15.2-0/solv' '-X' '/var/cache/zypp/raw/SLES15-SP2-15.2-0'
/var/cache/zypp/raw/SLES15-SP2-15.2-0/repodata/dabe2ce5481d23de1f4f52bdcfee0f9af98316c9e0de2ce8123adeefa0dd08b9-primary.xml.gz: No such file or directory
```

Related to https://github.com/yast/yast-installation/pull/889 and [bsc#1177522](https://bugzilla.suse.com/show_bug.cgi?id=1177522)