### PR TITLE
Adapt unit test to recent changes in Yast::Report

### DIFF
--- a/package/yast2-configuration-management.changes
+++ b/package/yast2-configuration-management.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 18 15:39:36 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Adapted unit test to recent changes in Yast::Report (related to
+  bsc#1179893).
+- 4.3.5
+
+-------------------------------------------------------------------
 Sat Oct 10 08:47:44 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Clean-up the libzypp's raw cache before running the finish client

--- a/package/yast2-configuration-management.spec
+++ b/package/yast2-configuration-management.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-configuration-management
-Version:        4.3.4
+Version:        4.3.5
 Release:        0
 Url:            https://github.com/yast/yast-migration
 Summary:        YaST2 - YaST Configuration Management

--- a/test/y2configuration_management/widgets/collection_test.rb
+++ b/test/y2configuration_management/widgets/collection_test.rb
@@ -29,7 +29,21 @@ describe Y2ConfigurationManagement::Widgets::Collection do
 
   subject(:collection) { described_class.new(spec, controller, locator) }
 
-  include_examples "CWM::CustomWidget"
+  context "with a correct value" do
+    before do
+      allow(subject).to receive(:value).and_return [double("item1"), double("item2")]
+    end
+
+    include_examples "CWM::CustomWidget"
+  end
+
+  context "with the default value" do
+    before do
+      allow(Yast::Report).to receive(:Error)
+    end
+
+    include_examples "CWM::CustomWidget"
+  end
 
   let(:form_spec) do
     Y2ConfigurationManagement::Salt::Form.from_file(

--- a/test/y2configuration_management/widgets/color_test.rb
+++ b/test/y2configuration_management/widgets/color_test.rb
@@ -64,7 +64,13 @@ describe Y2ConfigurationManagement::Widgets::Color do
     context "when the current value is not a valid HEX color" do
       let(:value) { "#ahrdfH" }
 
+      it "reports an error" do
+        expect(Yast::Report).to receive(:Error)
+        color.validate
+      end
+
       it "returns false" do
+        allow(Yast::Report).to receive(:Error)
         expect(color.validate).to eql(false)
       end
     end

--- a/test/y2configuration_management/widgets/email_test.rb
+++ b/test/y2configuration_management/widgets/email_test.rb
@@ -59,6 +59,7 @@ describe Y2ConfigurationManagement::Widgets::Email do
       end
 
       it "returns false" do
+        allow(Yast::Report).to receive(:Error)
         expect(email.validate).to eql(false)
       end
     end

--- a/test/y2configuration_management/widgets/key_value_test.rb
+++ b/test/y2configuration_management/widgets/key_value_test.rb
@@ -41,7 +41,22 @@ describe Y2ConfigurationManagement::Widgets::KeyValue do
   let(:key_widget) { dictionary.send(:key_widget) }
   let(:value_widget) { dictionary.send(:value_widget) }
   subject(:dictionary) { described_class.new(spec, locator) }
-  include_examples "CWM::CustomWidget"
+
+  context "with a valid value" do
+    before do
+      allow(key_widget).to receive(:value).and_return "YaST"
+    end
+
+    include_examples "CWM::CustomWidget"
+  end
+
+  context "with the initial value" do
+    before do
+      allow(Yast::Report).to receive(:Error)
+    end
+
+    include_examples "CWM::CustomWidget"
+  end
 
   describe "#contents" do
     it "contains a InputFIeld for the $key and $value" do
@@ -117,7 +132,13 @@ describe Y2ConfigurationManagement::Widgets::KeyValue do
     context "when the $key input is empty" do
       let(:key_widget_value) { "" }
 
+      it "reports an error" do
+        expect(Yast::Report).to receive(:Error)
+        subject.validate
+      end
+
       it "returns false" do
+        allow(Yast::Report).to receive(:Error)
         expect(subject.validate).to eql(false)
       end
     end

--- a/test/y2configuration_management/widgets/url_test.rb
+++ b/test/y2configuration_management/widgets/url_test.rb
@@ -59,6 +59,7 @@ describe Y2ConfigurationManagement::Widgets::URL do
       end
 
       it "returns false" do
+        allow(Yast::Report).to receive(:Error)
         expect(url.validate).to eql(false)
       end
     end


### PR DESCRIPTION
This pull request in yast-yast2 (https://github.com/yast/yast-yast2/pull/1122) changed the behavior during unit tests of `Yast::Report` and `Yast2::Popup`, making necessary to add some extra mocking to prevent YaST from trying to open windows during the test execution.

As far as we know, that affected the test-suites of: yast-autoinstallation, yast-add-on, yast-bootloader, yast-configuration-management, yast-dns-server, yast-installation, yast-kdump, yast-network, yast-nfs-client, yast-ntp-client, yast-storage-ng, yast-country, yast-firewall, yast-nfs-server, yast-nis-client, yast-pam, yast-security, yast-services-manager, yast-samba-server, yast-packager, yast-registration and yast-sysconfig.

This should fix the problem for this repository.