### PR TITLE
Fix hash vs keyword arguments in RSpec expectations (bsc#1204871)

### DIFF
--- a/package/yast2-configuration-management.changes
+++ b/package/yast2-configuration-management.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Oct 31 14:37:47 UTC 2022 - Martin Vidner <mvidner@suse.com>
+
+- Fix hash vs keyword arguments in RSpec expectations (bsc#1204871)
+- 4.5.1
+
+-------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.5.0 (bsc#1198109)

--- a/package/yast2-configuration-management.spec
+++ b/package/yast2-configuration-management.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-configuration-management
-Version:        4.5.0
+Version:        4.5.1
 Release:        0
 Url:            https://github.com/yast/yast-migration
 Summary:        YaST2 - YaST Configuration Management

--- a/test/y2configuration_management/clients/finish_client_test.rb
+++ b/test/y2configuration_management/clients/finish_client_test.rb
@@ -17,6 +17,8 @@ describe Y2ConfigurationManagement::ConfigurationManagementFinish do
         .and_return(configurator)
       allow(Y2ConfigurationManagement::Clients::Provision).to receive(:new)
         .and_return(provision_client)
+      allow(Dir).to receive(:exist?).with("/var/cache/zypp/raw").and_return(true)
+      allow(FileUtils).to receive(:rm_r).with("/var/cache/zypp/raw")
     end
 
     context "when not configuration is set" do

--- a/test/y2configuration_management/runners/puppet_test.rb
+++ b/test/y2configuration_management/runners/puppet_test.rb
@@ -30,10 +30,10 @@ describe Y2ConfigurationManagement::Runners::Puppet do
 
     context "when running in client mode" do
       it "runs puppet agent" do
+        opts = { stdout: $stdout, stderr: $stderr, chroot: "/mnt" }
         expect(Cheetah).to receive(:run)
           .with("puppet", "agent", "--onetime", "--no-daemonize",
-            "--waitforcert", config.auth_time_out.to_s, stdout: $stdout,
-            stderr: $stderr, chroot: "/mnt")
+            "--waitforcert", config.auth_time_out.to_s, opts)
         expect(runner.run).to eq(true)
       end
 
@@ -52,10 +52,11 @@ describe Y2ConfigurationManagement::Runners::Puppet do
       let(:master) { nil }
 
       it "runs salt-call" do
+        opts = { stdout: $stdout, stderr: $stderr, chroot: "/mnt" }
         expect(Cheetah).to receive(:run).with(
           "puppet", "apply", "--modulepath", config.work_dir.join("modules").to_s,
           config.work_dir.join("manifests", "site.pp").to_s,
-          stdout: $stdout, stderr: $stderr, chroot: "/mnt"
+          opts
         )
         expect(runner.run).to eq(true)
       end

--- a/test/y2configuration_management/runners/salt_test.rb
+++ b/test/y2configuration_management/runners/salt_test.rb
@@ -27,9 +27,10 @@ describe Y2ConfigurationManagement::Runners::Salt do
 
     context "when running in client mode" do
       it "runs salt-call" do
+        opts = { stdout: $stdout, stderr: $stderr, chroot: "/mnt" }
         expect(Cheetah).to receive(:run).with(
           "salt-call", "--log-level", "info", "state.highstate",
-          stdout: $stdout, stderr: $stderr, chroot: "/mnt"
+          opts
         )
         expect(runner.run).to eq(true)
       end
@@ -49,9 +50,10 @@ describe Y2ConfigurationManagement::Runners::Salt do
       let(:master) { nil }
 
       it "runs salt-call" do
+        opts = { stdout: $stdout, stderr: $stderr, chroot: "/mnt" }
         expect(Cheetah).to receive(:run).with(
           "salt-call", "--log-level", "info", "--local", "state.highstate",
-          stdout: $stdout, stderr: $stderr, chroot: "/mnt"
+          opts
         )
         expect(runner.run).to eq(true)
       end

--- a/test/y2configuration_management/widgets/pager_tree_item_test.rb
+++ b/test/y2configuration_management/widgets/pager_tree_item_test.rb
@@ -82,7 +82,8 @@ describe Y2ConfigurationManagement::Widgets::PagerTreeItem do
     end
 
     it "propagates the values to the pages" do
-      expect(page).to receive(:value=).with("name" => "OBS")
+      page_value = { "name" => "OBS" }
+      expect(page).to receive(:value=).with(page_value)
       expect(nested_page).to receive(:value=).with(new_value["labels"])
       item.value = new_value
     end


### PR DESCRIPTION
- https://bugzilla.opensuse.org/show_bug.cgi?id=1204871 "- [Staging] rubygem-rspec-* 3.12 breaks various yast modules build"
- see https://github.com/yast/yast-yast2/pull/1279 for details
