### PR TITLE
Fix build failure in Ruby 3.2

### DIFF
--- a/package/yast2-configuration-management.changes
+++ b/package/yast2-configuration-management.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jan 24 12:43:58 UTC 2023 - Martin Vidner <mvidner@suse.com>
+
+- Relax a unit test to work both with Ruby 3.1 and 3.2 (bsc#1207239)
+- 4.5.2
+
+-------------------------------------------------------------------
 Mon Oct 31 14:37:47 UTC 2022 - Martin Vidner <mvidner@suse.com>
 
 - Fix hash vs keyword arguments in RSpec expectations (bsc#1204871)

--- a/package/yast2-configuration-management.spec
+++ b/package/yast2-configuration-management.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-configuration-management
-Version:        4.5.1
+Version:        4.5.2
 Release:        0
 Url:            https://github.com/yast/yast-migration
 Summary:        YaST2 - YaST Configuration Management

--- a/test/y2configuration_management/file_from_url_wrapper_test.rb
+++ b/test/y2configuration_management/file_from_url_wrapper_test.rb
@@ -43,8 +43,7 @@ describe Y2ConfigurationManagement::FileFromUrlWrapper do
       expect(wrapper).to receive(:get_file_from_url).with(
         scheme: "usb", host: "",
         urlpath: "/some-file.txt",
-        urltok: { "scheme" => "usb", "path" => "", "query" => "", "fragment" => "",
-          "user" => "", "pass" => "", "port" => "", "host" => "some-file.txt" },
+        urltok: Hash,
         destdir: "/", localfile: "/tmp/local-file.txt"
       )
       wrapper.get_file(usb, target)


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1207239
- https://trello.com/c/jRe5bWVE

Since Ruby 3.2.0, there's been a bug fix it seems and URI::Generic no longer omits the host component (it is "" instead of nil)

```console
$ ruby -r uri -e 'p URI("dir:///foo").to_s'
"dir:/foo"    # up to 3.1.0
"dir:///foo"  # since 3.2.0
```

YaST builds fail in Staging:H

- yast2-packager
- yast2-configuration-manaegment


## Solution

Use a less specific matcher in that unit test, so that it passes with either behavior. The test was too specific for a simple wrapper anyway.


## Testing

- An existing unit tes


## Screenshots

N/A
